### PR TITLE
 Improve logging hypervisor selection 

### DIFF
--- a/igvm/hypervisor_preferences.py
+++ b/igvm/hypervisor_preferences.py
@@ -43,9 +43,11 @@ class OtherVMs(object):
         self.values = values
 
     def __repr__(self):
-        args = repr(self.attributes)
-        if self.values:
-            args += ', ' + repr(self.values)
+        args = ''
+        if self.attributes:
+            args += repr(self.attributes)
+            if self.values:
+                args += ', ' + repr(self.values)
 
         return '{}({})'.format(type(self).__name__, args)
 

--- a/igvm/hypervisor_ranking.py
+++ b/igvm/hypervisor_ranking.py
@@ -52,8 +52,6 @@ class HypervisorRanking(object):
 
         return rank
 
-    def decisive_preference(self):
-        """Return the last needed preference and its index"""
-        index = len(self.ranks) - 1
-
-        return HYPERVISOR_PREFERENCES[index], index
+    def get_last_preference_index(self):
+        """Return the index of the last needed preference"""
+        return len(self.ranks) - 1

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -160,7 +160,7 @@ HYPERVISOR_PREFERENCES = [
     # Prefer the hypervisor with less VMs from the same cluster
     OtherVMs(['project', 'environment', 'game_market']),
     # As the last resort, choose the hypervisor with less VMs
-    OtherVMs([]),
+    OtherVMs(),
     # Use hash differences to have a stable ordering
     HashDifference(),
 ]


### PR DESCRIPTION
This is the example output it produces:

```
DEBUG: Evaluating hypervisors...
WARNING: Preferred hypervisor "xxx" is skipped:  Not enough CPUs.  Destination hypervisor has 8, but VM requires 10.
WARNING: Preferred hypervisor "yyy" is skipped:  Not enough CPUs.  Destination hypervisor has 8, but VM requires 10.
INFO: Hypervisor "zzz" selected with decisive preference OtherVMs(['function'], ['master_db']) after checking 5 preferences.
WARNING: 16 hypervisors are equally preferred by 5 preferences:  InsufficientResource('disk_size_gib', reserved=32), InsufficientResource('memory'), HypervisorAttributeValueLimit('cpu_util_vm_pct', 45), OtherVMs(['project', 'function', 'environment', 'game_market', 'game_world', 'game_type']), OtherVMs(['game_world', 'function'], [0, 'db'])
WARNING: 27 hypervisors are equally preferred by 3 preferences:  InsufficientResource('disk_size_gib', reserved=32), InsufficientResource('memory'), HypervisorAttributeValueLimit('cpu_util_vm_pct', 45)
WARNING: All 28 hypervisors are equally preferred by 2 preferences:  InsufficientResource('disk_size_gib', reserved=32), InsufficientResource('memory')
```
