### PR TITLE
Disable backups for test vms by default

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -142,6 +142,7 @@ class IGVMTest(TestCase):
             'int:innogames:stable jessie',
         ]
         obj['puppet_environment'] = None
+        obj['backup_disabled'] = True
         obj.commit()
 
     def tearDown(self):


### PR DESCRIPTION
Having backups enabled spams the dead backups table in our backup server