### PR TITLE
Close connections after tests are finished

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -42,6 +42,7 @@ from igvm.settings import (
     IMAGE_PATH,
 )
 from igvm.utils.units import parse_size
+from fabric.network import disconnect_all
 
 basicConfig(level=INFO)
 env.update(COMMON_FABRIC_SETTINGS)
@@ -92,6 +93,7 @@ def tearDownModule():
     for obj in query:
         obj.delete()
     query.commit()
+    disconnect_all()  # Will hang on Jessie + Python3
 
 
 def cmd(cmd, *args, **kwargs):


### PR DESCRIPTION
This seems rather a workaround. We stumbled upon this problem when we
moved tests to Python3 - tests never finish and Paramiko stays connected.

This is known on combination Jessie HV + Jessie control-test + Python3.