### PR TITLE
Make sure total_vm_memory() returns an int

### DIFF
--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -512,7 +512,7 @@ class Hypervisor(Host):
     def total_vm_memory(self):
         """Get amount of memory in MiB available to hypervisor"""
         # Start with what OS sees as total memory (not installed memory)
-        total_mib = self.conn().getMemoryStats(-1)['total'] / 1024
+        total_mib = self.conn().getMemoryStats(-1)['total'] // 1024
         # Always keep some extra memory free for Hypervisor
         total_mib -= HOST_RESERVED_MEMORY
         return total_mib


### PR DESCRIPTION
Ultimately this is used to calculate the DomainProperties.max_mem
property. The libvirt python lib expects us to pass in an int here.