### PR TITLE
Maintain object_id as a part of the libvirt domain and lv name

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -312,6 +312,7 @@ def vm_restart(vm_hostname, force=False, no_redefine=False):
         vm.shutdown()
 
     if not no_redefine:
+        vm.hypervisor.vm_lv_update_name(vm)
         vm.hypervisor.redefine_vm(vm)
 
     vm.start()

--- a/igvm/drbd.py
+++ b/igvm/drbd.py
@@ -11,13 +11,15 @@ log = getLogger(__name__)
 
 
 class DRBD(object):
-    def __init__(self, hv, vg_name, lv_name, vm_name, master_role=False):
+    def __init__(self, hv, vm, master_role=False):
         self.hv = hv
-        self.vg_name = vg_name
-        self.lv_name = lv_name
-        self.vm_name = vm_name
         self.master_role = master_role
-        self.meta_disk = self.vm_name + '_meta'
+
+        lv = vm.hypervisor.vm_lv_get(vm)
+        self.vg_name = lv['vg_name']
+        self.lv_name = lv['name'] if self.master_role else vm.uid_name
+        self.vm_name = vm.fqdn
+        self.meta_disk = vm.fqdn + '_meta'
         self.table_file = '/tmp/{}_{}_table'.format(self.vg_name, self.lv_name)
 
         # Cached properties
@@ -152,7 +154,6 @@ class DRBD(object):
                 addr=self.hv.dataset_obj['intern_ip'],
                 port=self.get_device_port(),
                 dm_minor=self.get_device_minor(),
-                vm_name=self.vm_name,
                 lv_name=self.lv_name,
                 disk=(
                     'mapper/{}_orig'.format(self.lv_name)

--- a/igvm/drbd.py
+++ b/igvm/drbd.py
@@ -15,7 +15,7 @@ class DRBD(object):
         self.hv = hv
         self.master_role = master_role
 
-        lv = vm.hypervisor.vm_lv_get(vm)
+        lv = vm.hypervisor.get_lv_by_vm(vm)
         self.vg_name = lv['vg_name']
         self.lv_name = lv['name'] if self.master_role else vm.uid_name
         self.vm_name = vm.fqdn

--- a/igvm/host.py
+++ b/igvm/host.py
@@ -41,6 +41,22 @@ class Host(object):
     def __eq__(self, other):
         return isinstance(other, Host) and self.fqdn == other.fqdn
 
+    @property
+    def uid_name(self):
+        """Name readable by both humans and machines
+
+        Don't just assume this is the current domain or lv name of a VM. The
+        whole point of these names is that hostnames may change while
+        object_id may not.
+        """
+        return '{}_{}'.format(
+            self.dataset_obj['object_id'],
+            self.dataset_obj['hostname'])
+
+    def match_uid_name(self, uid_name):
+        """Check if a given uid_name matches this host"""
+        return uid_name.split('_', 1)[0] == str(self.dataset_obj['object_id'])
+
     def fabric_settings(self, *args, **kwargs):
         """Builds a fabric context manager to run commands on this host."""
         settings = COMMON_FABRIC_SETTINGS.copy()

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -70,7 +70,7 @@ class Hypervisor(Host):
             ):
                 return lv
 
-        raise HypervisorError(
+        raise StorageError(
             'No existing LV found for VM "{}" on "{}".'
             .format(vm.fqdn, self.fqdn)
         )

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -57,12 +57,27 @@ class Hypervisor(Host):
         # We cannot store these in the VM object due to migrations.
         self._mount_path = {}
 
-    def vm_disk_path(self, name):
-        return '/dev/{}/{}'.format(VG_NAME, name)
+    def vm_lv_get(self, vm):
+        """Get a VMs logical volume information"""
+        lvs = self.get_logical_volumes()
+        domain = self._find_domain(vm)
+        for lv in lvs:
+            if (
+                # Match the LV based on the object_id encoded within its name
+                vm.match_uid_name(lv['name']) or
+                # XXX: Deprecated matching for LVs w/o an uid_name
+                domain and lv['name'] == domain.name()
+            ):
+                return lv
+
+        raise HypervisorError(
+            'No existing LV found for VM "{}" on "{}".'
+            .format(vm.fqdn, self.fqdn)
+        )
 
     def vm_mount_path(self, vm):
-        """Returns the mount path for a VM.
-        Raises HypervisorError if not mounted."""
+        """Returns the mount path for a VM or raises HypervisorError if not
+        mounted."""
         if vm not in self._mount_path:
             raise HypervisorError(
                 '"{}" is not mounted on "{}".'
@@ -285,18 +300,20 @@ class Hypervisor(Host):
         """Changes disk size of a VM."""
         if new_size_gib < vm.dataset_obj['disk_size_gib']:
             raise NotImplementedError('Cannot shrink the disk.')
-        domain = self._get_domain(vm)
         with self.fabric_settings():
-            self.lvresize(self.vm_disk_path(domain.name()), new_size_gib)
+            self.lv_resize(self.vm_lv_get(vm)['path'], new_size_gib)
 
         self._vm_set_disk_size_gib(vm, new_size_gib)
 
-    def create_vm_storage(self, vm, name, transaction=None):
+    def create_vm_storage(self, vm, lv_name, transaction=None):
         """Allocate storage for a VM. Returns the disk path."""
-        self.create_storage(name, vm.dataset_obj['disk_size_gib'])
+
+        self.lv_create(lv_name, vm.dataset_obj['disk_size_gib'])
         if transaction:
             transaction.on_rollback(
-                'destroy storage', self.lvremove, self.vm_disk_path(name)
+                'destroy storage',
+                self.lv_remove,
+                '/dev/{}/{}'.format(VG_NAME, lv_name),
             )
 
     def format_vm_storage(self, vm, transaction=None):
@@ -308,7 +325,7 @@ class Hypervisor(Host):
                 .format(vm.fqdn)
             )
 
-        self.format_storage(self.vm_disk_path(vm.fqdn))
+        self.format_storage(self.vm_lv_get(vm)['path'])
         return self.mount_vm_storage(vm, transaction)
 
     def download_and_extract_image(self, image, target_dir):
@@ -348,7 +365,7 @@ class Hypervisor(Host):
             )
 
         self._mount_path[vm] = self.mount_temp(
-            self.vm_disk_path(vm.fqdn), suffix=('-' + vm.fqdn)
+            self.vm_lv_get(vm)['path'], suffix=('-' + vm.fqdn)
         )
         if transaction:
             transaction.on_rollback(
@@ -372,13 +389,10 @@ class Hypervisor(Host):
         the hypervisor. Returns a dict with all collected values."""
         # Update disk size
         result = {}
-        lvs = self.get_logical_volumes()
-        domain = self._get_domain(vm)
-        for lv in lvs:
-            if lv['name'] == domain.name():
-                result['disk_size_gib'] = int(math.ceil(lv['size_MiB'] / 1024))
-                break
-        else:
+        try:
+            lv = self.vm_lv_get(vm)
+            result['disk_size_gib'] = int(math.ceil(lv['size_MiB'] / 1024))
+        except HypervisorError:
             raise HypervisorError(
                 'Unable to find source LV and determine its size.'
             )
@@ -410,8 +424,14 @@ class Hypervisor(Host):
         # the console.
         for domain in self.conn().listAllDomains():
             name = domain.name()
-            if not (vm.fqdn == name or vm.fqdn.startswith(name + '.')):
+            if not (
+                # Match the domain based on the object_id encoded in its name
+                vm.match_uid_name(name) or
+                # XXX: Deprecated matching for domains w/o an uid_name
+                vm.fqdn == name or vm.fqdn.startswith(name + '.')
+            ):
                 continue
+
             if found is not None:
                 raise HypervisorError(
                     'Same VM is defined multiple times as "{}" and "{}".'
@@ -507,9 +527,7 @@ class Hypervisor(Host):
         domain = self._get_domain(vm)
         self.run(
             'virsh blockresize --path {} --size {}GiB {}'
-            .format(
-                self.vm_disk_path(domain.name()), disk_size_gib, domain.name()
-            )
+            .format(self.vm_lv_get(vm)['path'], disk_size_gib, domain.name())
         )
         vm.run('xfs_growfs /')
 
@@ -551,11 +569,12 @@ class Hypervisor(Host):
                 'Refusing to undefine running VM "{}"'.format(vm.fqdn)
             )
         log.info('Undefining "{}" on "{}"'.format(vm.fqdn, self.fqdn))
+        lv_path = self.vm_lv_get(vm)['path']
         domain = self._get_domain(vm)
         if domain.undefine() != 0:
             raise HypervisorError('Unable to undefine "{}".'.format(vm.fqdn))
         if not keep_storage:
-            self.lvremove(self.vm_disk_path(domain.name()))
+            self.lv_remove(lv_path)
 
     def redefine_vm(self, vm):
         domain = self._get_domain(vm)
@@ -606,16 +625,22 @@ class Hypervisor(Host):
             })
         return lvolumes
 
-    def lvremove(self, lv):
-        self.run('lvremove -f {0}'.format(lv))
+    def lv_create(self, lv_name, size_gib):
+        self.run('lvcreate -y -L {}g -n {} {}'.format(
+            size_gib,
+            lv_name,
+            VG_NAME,
+        ))
 
-    def lvresize(self, volume, size_gib):
+    def lv_remove(self, lv_path):
+        self.run('lvremove -f {0}'.format(lv_path))
+
+    def lv_resize(self, lv_path, size_gib):
         """Extend the volume, return the new size"""
+        self.run('lvresize {0} -L {1}g'.format(lv_path, size_gib))
 
-        self.run('lvresize {0} -L {1}g'.format(volume, size_gib))
-
-    def lvrename(self, volume, newname):
-        self.run('lvrename {0} {1}'.format(volume, newname))
+    def lv_rename(self, lv_path, new_lv_name):
+        self.run('lvrename {0} {1}'.format(lv_path, new_lv_name))
 
     def get_free_disk_size_gib(self, safe=True):
         """Return free disk space as float in GiB"""
@@ -632,13 +657,6 @@ class Hypervisor(Host):
             vg_size_gib -= RESERVED_DISK
         assert vg_name == VG_NAME
         return vg_size_gib
-
-    def create_storage(self, name, disk_size_gib):
-        self.run('lvcreate -y -L {}g -n {} {}'.format(
-            disk_size_gib,
-            name,
-            VG_NAME,
-        ))
 
     def mount_temp(self, device, suffix=''):
         mount_dir = self.run('mktemp -d --suffix {}'.format(suffix))

--- a/igvm/kvm.py
+++ b/igvm/kvm.py
@@ -351,8 +351,8 @@ def generate_domain_xml(hypervisor, vm):
     vlan_network = hypervisor.get_vlan_network(vm.dataset_obj['intern_ip'])
 
     config = {
-        'disk_device': '/dev/{}/{}'.format(VG_NAME, vm.fqdn),
-        'fqdn': vm.fqdn,
+        'name': vm.uid_name,
+        'disk_device': hypervisor.vm_lv_get(vm)['path'],
         'memory': vm.dataset_obj['memory'],
         'num_cpu': vm.dataset_obj['num_cpu'],
         'props': props,

--- a/igvm/kvm.py
+++ b/igvm/kvm.py
@@ -352,7 +352,7 @@ def generate_domain_xml(hypervisor, vm):
 
     config = {
         'name': vm.uid_name,
-        'disk_device': hypervisor.vm_lv_get(vm)['path'],
+        'disk_device': hypervisor.get_lv_by_vm(vm)['path'],
         'memory': vm.dataset_obj['memory'],
         'num_cpu': vm.dataset_obj['num_cpu'],
         'props': props,

--- a/igvm/templates/domain.xml
+++ b/igvm/templates/domain.xml
@@ -1,12 +1,12 @@
 <domain type='kvm'>
-  <name>{{ fqdn }}</name>
+  <name>{{ name }}</name>
   <uuid>{{ props.uuid }}</uuid>
 {% if props.mem_hotplug %}
   <maxMemory slots='16' unit='MiB'>{{ props.max_mem }}</maxMemory>
 {% endif %}
   <memory unit='MiB'>{{ memory }}</memory>
   <currentMemory unit='MiB'>{{ memory }}</currentMemory>
-  
+
   <!-- Don't put placement attribute unless NUMA settings are set! -->
   <vcpu current='{{ num_cpu }}'>{{ props.max_cpus }}</vcpu>
 

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -313,7 +313,7 @@ class VM(Host):
 
         with Transaction() as transaction:
             # Perform operations on the hypervisor
-            self.hypervisor.create_vm_storage(self, self.fqdn, transaction)
+            self.hypervisor.create_vm_storage(self, self.uid_name, transaction)
             mount_path = self.hypervisor.format_vm_storage(self, transaction)
 
             self.hypervisor.download_and_extract_image(image, mount_path)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -148,17 +148,17 @@ class IGVMTest(TestCase):
 
     def tearDown(self):
         """Clean up all HVs after every test"""
+
+        vm_obj = Query({'hostname': VM_HOSTNAME}, ['hostname']).get()
+        uid_name = '{}_{}'.format(vm_obj['object_id'], vm_obj['hostname'])
+
         for hv in HYPERVISORS:
             hv.run(
                 'virsh destroy {vm}; '
-                'virsh undefine {vm}'
-                .format(vm=VM_HOSTNAME),
-                warn_only=True,
-            )
-            hv.run(
+                'virsh undefine {vm}; '
                 'umount /dev/xen-data/{vm}; '
                 'lvremove -f /dev/xen-data/{vm}'
-                .format(vm=VM_HOSTNAME),
+                .format(vm=uid_name),
                 warn_only=True,
             )
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,6 +39,7 @@ from igvm.settings import (
     COMMON_FABRIC_SETTINGS,
     HYPERVISOR_ATTRIBUTES,
     IMAGE_PATH,
+    VG_NAME,
 )
 from igvm.utils import parse_size
 from fabric.network import disconnect_all
@@ -156,9 +157,9 @@ class IGVMTest(TestCase):
             hv.run(
                 'virsh destroy {vm}; '
                 'virsh undefine {vm}; '
-                'umount /dev/xen-data/{vm}; '
-                'lvremove -f /dev/xen-data/{vm}'
-                .format(vm=uid_name),
+                'umount /dev/{vg}/{vm}; '
+                'lvremove -f /dev/{vg}/{vm}'
+                .format(vg=VG_NAME, vm=uid_name),
                 warn_only=True,
             )
 
@@ -174,7 +175,7 @@ class IGVMTest(TestCase):
             else:
                 # Is it gone from other HVs after migration?
                 self.assertEqual(hv.vm_defined(vm), False)
-                hv.run('test ! -b /dev/xen-data/{}'.format(vm.fqdn))
+                hv.run('test ! -b /dev/{}/{}'.format(VG_NAME, vm.fqdn))
 
         # Is VM itself alive and fine?
         fqdn = vm.run('hostname -f').strip()
@@ -191,7 +192,7 @@ class IGVMTest(TestCase):
         for hv in HYPERVISORS:
             if hv.dataset_obj['hostname'] == hv_name:
                 self.assertEqual(hv.vm_defined(vm), False)
-                hv.run('test ! -b /dev/xen-data/{}'.format(vm.fqdn))
+                hv.run('test ! -b /dev/{}/{}'.format(VG_NAME, vm.fqdn))
 
 
 class BuildTest(IGVMTest):


### PR DESCRIPTION
This MR changes the name of new libvirt domains and logical volumes from just the hostname to the object_id followed by the current hostname of the VMs serveradmin object . The object_id of a VM is immutable while the hostname is not. It's therefore much safer to correlate VMs by this ID. The domain and lv name of old VMs will be changed to the new version during an offline migration or when restarting the VM via igvm.
Once all VMs have been restarted, offline migrated or recreated we can remove the backward compatible hostname matching still maintained in this version.