### PR TITLE
Fix delete_vm() for legacy hosts with no uid prefix in their lv name

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -335,7 +335,6 @@ def vm_restart(vm_hostname, force=False, no_redefine=False):
             vm.shutdown()
 
         if not no_redefine:
-            vm.hypervisor.vm_lv_update_name(vm)
             vm.hypervisor.redefine_vm(vm)
 
         vm.start()

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -208,7 +208,7 @@ def vm_migrate(vm_hostname, hypervisor_hostname=None, newip=None,
             if vm.hypervisor.fqdn == hypervisor.fqdn:
                 raise IGVMError(
                     'Source and destination Hypervisor is the same!'
-                    )
+                )
         else:
             hypervisor = es.enter_context(_get_best_hypervisor(
                 vm,

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -181,7 +181,7 @@ def vm_build(vm_hostname, run_puppet=True, debug_puppet=False, postboot=None,
             )
 
         if rebuild and vm.hypervisor.vm_defined(vm):
-            vm.hypervisor.delete_vm(vm)
+            vm.hypervisor.undefine_vm(vm)
 
         vm.build(
             run_puppet=run_puppet,
@@ -282,7 +282,7 @@ def vm_migrate(vm_hostname, hypervisor_hostname=None, newip=None,
 
         # If removing the existing VM fails we shouldn't risk undoing the newly
         # migrated one.
-        previous_hypervisor.delete_vm(vm)
+        previous_hypervisor.undefine_vm(vm)
 
 
 @with_fabric_settings
@@ -361,7 +361,7 @@ def vm_delete(vm_hostname, retire=False):
 
         # Delete the VM from its hypervisor if required.
         if vm.hypervisor and vm.hypervisor.vm_defined(vm):
-            vm.hypervisor.delete_vm(vm)
+            vm.hypervisor.undefine_vm(vm)
 
         # Delete the serveradmin object of this VM
         # or update its state to 'retired' if retire is True.

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -616,17 +616,14 @@ class Hypervisor(Host):
         if self._get_domain(vm).undefine() != 0:
             raise HypervisorError('Unable to undefine "{}".'.format(vm.fqdn))
 
-    def redefine_vm(self, vm):
-        domain = self._get_domain(vm)
-        self.undefine_vm(vm, keep_storage=True)
-        if domain.name() != vm.fqdn:
-            self.vm_lv_update_name(vm)
-        self.define_vm(vm)
-
-    def rename_vm(self, vm, new_fqdn):
-        self.undefine_vm(vm, keep_storage=True)
+    def redefine_vm(self, vm, new_fqdn=None):
+        # XXX: vm_lv_update_name depends on domain names to find legacy domains
+        # w/o an uid_name.  The order is therefore important.
         self.vm_lv_update_name(vm)
-        vm.fqdn = new_fqdn
+        self.undefine_vm(vm, keep_storage=True)
+        # XXX: undefine_vm depends on vm.fqdn beeing the old name for finding
+        # legacy domains w/o an uid_name.  The order is therefore important.
+        vm.fqdn = new_fqdn or vm.fqdn
         self.define_vm(vm)
 
     def _vm_sync_from_hypervisor(self, vm, result):

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -217,7 +217,7 @@ class Hypervisor(Host):
             pool.refresh(0)
         if transaction:
             transaction.on_rollback(
-                'delete VM', self.delete_vm, vm, keep_storage=True
+                'delete VM', self.undefine_vm, vm, keep_storage=True
             )
 
     def _check_committed(self, vm):
@@ -601,7 +601,7 @@ class Hypervisor(Host):
                 'Unable to force-stop "{}".'.format(vm.fqdn)
             )
 
-    def delete_vm(self, vm, keep_storage=False):
+    def undefine_vm(self, vm, keep_storage=False):
         if self.vm_running(vm):
             raise InvalidStateError(
                 'Refusing to undefine running VM "{}"'.format(vm.fqdn)
@@ -618,13 +618,13 @@ class Hypervisor(Host):
 
     def redefine_vm(self, vm):
         domain = self._get_domain(vm)
-        self.delete_vm(vm, keep_storage=True)
+        self.undefine_vm(vm, keep_storage=True)
         if domain.name() != vm.fqdn:
             self.vm_lv_update_name(vm)
         self.define_vm(vm)
 
     def rename_vm(self, vm, new_fqdn):
-        self.delete_vm(vm, keep_storage=True)
+        self.undefine_vm(vm, keep_storage=True)
         self.vm_lv_update_name(vm)
         vm.fqdn = new_fqdn
         self.define_vm(vm)

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -608,11 +608,13 @@ class Hypervisor(Host):
             )
         log.info('Undefining "{}" on "{}"'.format(vm.fqdn, self.fqdn))
 
-        domain = self._get_domain(vm)
-        if domain.undefine() != 0:
-            raise HypervisorError('Unable to undefine "{}".'.format(vm.fqdn))
         if not keep_storage:
+            # XXX: get_volume_by_vm depends on domain names to find legacy
+            # domains w/o an uid_name.  The order is therefore important.
             self.get_volume_by_vm(vm).delete()
+
+        if self._get_domain(vm).undefine() != 0:
+            raise HypervisorError('Unable to undefine "{}".'.format(vm.fqdn))
 
     def redefine_vm(self, vm):
         domain = self._get_domain(vm)

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -376,7 +376,7 @@ class VM(Host):
 
         with Transaction() as transaction:
             self.shutdown(transaction=transaction)
-            self.hypervisor.rename_vm(self, new_hostname)
+            self.hypervisor.redefine_vm(self, new_fqdn=new_hostname)
 
             self.dataset_obj.commit()
 


### PR DESCRIPTION
Patrick had a rebuild failing as get_volume_by_vm() matches first by
uid prefix and secondly by lv name == domain name. The latter does
not match as the domain is already deleted at this point in
delete_vm().