### PR TITLE
Keep VM up on original HV after migration failure

### DIFF
--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -570,12 +570,18 @@ class Hypervisor(Host):
                     vm.set_state('maintenance', transaction=transaction)
 
                     if vm.is_running():
-                        vm.shutdown(transaction)
+                        vm.shutdown(
+                            check_vm_up_on_transaction=False,
+                            transaction=transaction,
+                        )
 
             elif offline_transport == 'netcat':
                 vm.set_state('maintenance', transaction=transaction)
                 if vm.is_running():
-                    vm.shutdown(transaction)
+                        vm.shutdown(
+                            check_vm_up_on_transaction=False,
+                            transaction=transaction,
+                        )
                 vm_disk_path = target_hypervisor.get_volume_by_vm(vm).path()
                 with target_hypervisor.netcat_to_device(vm_disk_path) as args:
                     self.device_to_netcat(


### PR DESCRIPTION
Sometimes we have migration failing because VM takes too long to boot. Not because anything is really broken but the VM just misbehaves doe to some services that take too long to start. In such cases migration will fail (fixing this is another issue) and even reverting migration will fail. With this patch VM is started on original HV unconditionally.