### PR TITLE
Enforce smaller block size before DRBD migration starts

### DIFF
--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -539,6 +539,23 @@ class Hypervisor(Host):
 
                 host_drbd = DRBD(self, vm, master_role=True)
                 peer_drbd = DRBD(target_hypervisor, vm)
+                if vm.hypervisor.vm_running(vm):
+                    vm_block_size = vm.get_block_size('/dev/vda')
+                    src_block_size = vm.hypervisor.get_block_size(
+                        vm.hypervisor.get_volume_by_vm(vm).path()
+                    )
+                    dst_block_size = target_hypervisor.get_block_size(
+                        target_hypervisor.get_volume_by_vm(vm).path()
+                    )
+                    log.debug(
+                        'Block sizes: VM {}, Source HV {}, Destination HV {}'
+                        .format(vm_block_size, src_block_size, dst_block_size)
+                    )
+                    vm.set_block_size('vda', min(
+                        vm_block_size,
+                        src_block_size,
+                        dst_block_size,
+                    ))
                 with host_drbd.start(peer_drbd), peer_drbd.start(host_drbd):
                     # XXX: Do we really need to wait for the both?
                     host_drbd.wait_for_sync()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,6 +12,7 @@ from pipes import quote
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 from uuid import uuid4
+from pytest import mark
 
 from adminapi.dataset import Query
 from fabric.api import env
@@ -540,6 +541,7 @@ class MigrationTest(IGVMTest):
                 newip='1.2.3.4',
             )
 
+    @mark.skip(reason="Serveradmin can't give out unique IP address yet")
     def test_new_ip(self):
         # We don't have a way to ask for new IP address from Serveradmin
         # and lock it for us. The method below will usually work fine.


### PR DESCRIPTION
Problem on VM:
```
XFS (vda): xfs_log_force: error 5 returned.
```

Problem on HV:
```
bio too big device drbd0 (16 > 8)
```