### PR TITLE
Add command to evacuate all VMs out of a hypervisor

### DIFF
--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -12,6 +12,7 @@ from fabric.network import disconnect_all
 
 from igvm.commands import (
     disk_set,
+    evacuate,
     host_info,
     mem_set,
     vcpu_set,
@@ -354,6 +355,26 @@ def parse_args():
         '--offline',
         action='store_true',
         help='Shutdown VM, if running',
+    )
+
+    subparser = subparsers.add_parser(
+        'evacuate',
+        description=evacuate.__doc__,
+    )
+    subparser.set_defaults(func=evacuate)
+    subparser.add_argument(
+        'hv_hostname',
+        help='Hostname of the hypervisor',
+    )
+    subparser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Do not migrate but just print what would be done'
+    )
+    subparser.add_argument(
+        '--offline',
+        nargs='*',
+        help='Migrate VMs offline',
     )
 
     return vars(top_parser.parse_args())

--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -374,7 +374,7 @@ def parse_args():
     subparser.add_argument(
         '--offline',
         nargs='*',
-        help='Migrate VMs offline',
+        help='Migrate VMs matching the given serveradmin function offline',
     )
 
     return vars(top_parser.parse_args())

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -64,7 +64,7 @@ def evacuate(hv_hostname, offline=None, dry_run=False):
 
     with _get_hypervisor(hv_hostname, ignore_reserved=True) as hv:
         if dry_run:
-            log.info('Setting {} to state maintenance'.format(hv_hostname))
+            log.info('I would set {} to state maintenance'.format(hv_hostname))
         else:
             hv.dataset_obj['state'] = 'maintenance'
             hv.dataset_obj.commit()
@@ -77,12 +77,12 @@ def evacuate(hv_hostname, offline=None, dry_run=False):
                 (offline == [] or vm_function in offline)
             ):
                 if dry_run:
-                    log.info('migrating {} offline'.format(vm['hostname']))
+                    log.info('Would migrate {} offline'.format(vm['hostname']))
                 else:
                     vm_migrate(vm['hostname'], offline=True)
             else:
                 if dry_run:
-                    log.info('migrating {} online'.format(vm['hostname']))
+                    log.info('Would migrate {} online'.format(vm['hostname']))
                 else:
                     vm_migrate(vm['hostname'])
 

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -62,10 +62,7 @@ def evacuate(hv_hostname, offline=None, dry_run=False):
     a list of strings is passed only those matching will be migrate offline.
     """
 
-    with ExitStack() as es:
-        hv = es.enter_context(
-            _get_hypervisor(hv_hostname, ignore_reserved=True))
-
+    with _get_hypervisor(hv_hostname, ignore_reserved=True) as hv:
         if dry_run:
             log.info('Setting {} to state maintenance'.format(hv_hostname))
         else:


### PR DESCRIPTION
Add a command to evacuate all VMs from a hypervisor and set it to maintenance. Also supports migrating VMs offline or only specific VMs matching function attribute offline. Also adds dry mode.