### PR TITLE
Give parameters more meaningful names

### DIFF
--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -114,9 +114,9 @@ def parse_args():
     )
     subparser.add_argument(
         '--ignore-reserved',
-        dest='ignore_reserved',
+        dest='allow_reserved_hv',
         action='store_true',
-        help='Force build on a Host which has the state online_reserved',
+        help='Allow building on a Host which has the state online_reserved',
     )
     subparser.add_argument(
         '--rebuild',
@@ -162,9 +162,9 @@ def parse_args():
     )
     subparser.add_argument(
         '--ignore-reserved',
-        dest='ignore_reserved',
+        dest='allow_reserved_hv',
         action='store_true',
-        help='Force migration to a Host which has the state online_reserved',
+        help='Allow migration to a Host which has the state online_reserved',
     )
     subparser.add_argument(
         '--offline-transport',
@@ -197,12 +197,6 @@ def parse_args():
             'Can be specified relative with "+". Only integers are allowed'
         )
     )
-    subparser.add_argument(
-        '--ignore-reserved',
-        dest='ignore_reserved',
-        action='store_true',
-        help='Force setting disk on a hypervisor with state online_reserved',
-    )
 
     subparser = subparsers.add_parser(
         'mem-set',
@@ -225,12 +219,6 @@ def parse_args():
         action='store_true',
         help='Shutdown VM, change memory, and restart VM',
     )
-    subparser.add_argument(
-        '--ignore-reserved',
-        dest='ignore_reserved',
-        action='store_true',
-        help='Force setting memory on a hypervisor with state online_reserved',
-    )
 
     subparser = subparsers.add_parser(
         'vcpu-set',
@@ -250,12 +238,6 @@ def parse_args():
         '--offline',
         action='store_true',
         help='Shutdown VM, change CPUs, and restart VM',
-    )
-    subparser.add_argument(
-        '--ignore-reserved',
-        dest='ignore_reserved',
-        action='store_true',
-        help='Force setting cpus on a hypervisor with state online_reserved',
     )
 
     subparser = subparsers.add_parser(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -194,7 +194,7 @@ class IGVMTest(TestCase):
 
     def check_vm_absent(self, hv_name=None):
         # Operate on fresh object
-        with _get_vm(VM_HOSTNAME, ignore_retired=True) as vm:
+        with _get_vm(VM_HOSTNAME, allow_retired=True) as vm:
             if not hv_name:
                 hv_name = vm.dataset_obj['hypervisor']
 


### PR DESCRIPTION
And always allow to modify VM's CPUs, disk and memory. It was never the
HV being checked for being online_reserved but a VM and that was not a
correct state for a VM anyway. And the attribute was not checked in
_get_vm at all.