### PR TITLE
Fix host objects lock not released after crash

### DIFF
--- a/igvm/host.py
+++ b/igvm/host.py
@@ -4,6 +4,7 @@ Copyright (c) 2018 InnoGames GmbH
 """
 
 from io import BytesIO
+from datetime import datetime
 
 import fabric.api
 import fabric.state
@@ -138,13 +139,13 @@ class Host(object):
             )
 
     def acquire_lock(self, allow_fail=False):
-        if self.dataset_obj['igvm_locked']:
+        if self.dataset_obj['igvm_locked'] is not None:
             raise InvalidStateError(
                 'Server "{0}" is already being worked on by another igvm'
                 .format(self.dataset_obj['hostname'])
             )
 
-        self.dataset_obj['igvm_locked'] = True
+        self.dataset_obj['igvm_locked'] = int(datetime.utcnow().timestamp())
         try:
             self.dataset_obj.commit()
         except DatasetError:
@@ -154,7 +155,7 @@ class Host(object):
             )
 
     def release_lock(self):
-        self.dataset_obj['igvm_locked'] = False
+        self.dataset_obj['igvm_locked'] = None
         self.dataset_obj.commit()
 
     def get_block_size(self, device):


### PR DESCRIPTION
We experienced that some objects such as hypervisors and VMs are not
porperly release their lock when igvm crashed or gets aborted by closing
the terminal or hitting ctrl-c many times in a row or the process gets
killed etc.

To get rid of this problem we should change igvm_locked to a number value
and work with timestamps so that we can check if a object has been locked
for too long as it is currently not possible to query serveradmin
history via API and this requires greater refactoring.