### PR TITLE
Remove rootuser for puppet access

### DIFF
--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -424,7 +424,6 @@ class VM(Host):
         if clear_cert:
             with settings(
                 host_string=self.dataset_obj['puppet_ca'],
-                user='root',
                 warn_only=True,
             ):
                 run(


### PR DESCRIPTION
Root access should be disabled everywhere, so we shouldn't rely on it.