### PR TITLE
Use IGVM_SSH_USER to get libvirt user and check SSH config

### DIFF
--- a/igvm/libvirt.py
+++ b/igvm/libvirt.py
@@ -3,20 +3,23 @@
 Copyright (c) 2018 InnoGames GmbH
 """
 
-from fabric.api import env
 from libvirt import open as libvirt_open, libvirtError
-from os import path
+from os import path, environ
 
+from igvm.utils import get_ssh_config
 
 _conns = {}
 
 
 def get_virtconn(fqdn):
-    # Unfortunately required for igvm intergration testing
-    if 'user' in env:
-        username = env['user'] + '@'
+    if 'IGVM_SSH_USER' in environ:
+        username = environ.get('IGVM_SSH_USER') + '@'
     else:
-        username = ''
+        ssh_config = get_ssh_config(fqdn)
+        if 'user' in ssh_config:
+            username = ssh_config['user'] + '@'
+        else:
+            username = ''
 
     scripts_dir = path.join(path.dirname(__file__), 'scripts')
 

--- a/igvm/utils.py
+++ b/igvm/utils.py
@@ -8,6 +8,9 @@ from __future__ import division
 import logging
 import socket
 import time
+from os import path
+
+from paramiko import SSHConfig
 
 from igvm.exceptions import TimeoutError
 
@@ -146,3 +149,21 @@ def convert_size(size, from_name, to_name):
     return size / (
         _SIZE_FACTORS[from_name.upper()] * _SIZE_FACTORS[to_name.upper()]
     )
+
+
+def get_ssh_config(hostname):
+    """Get SSH config for given hostname
+
+    :param: hostname: hostname
+
+    :return: dict
+    """
+
+    ssh_config_file = path.abspath(path.expanduser('~/.ssh/config'))
+    if path.exists(ssh_config_file):
+        ssh_config = SSHConfig()
+        with open(ssh_config_file) as f:
+            ssh_config.parse(f)
+            return ssh_config.lookup(hostname)
+
+    return dict()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,17 +6,17 @@ Copyright (c) 2018 InnoGames GmbH
 from __future__ import print_function
 
 from logging import INFO, basicConfig
-from libvirt import VIR_DOMAIN_RUNNING
 from os import environ
 from pipes import quote
+from re import match
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 from uuid import uuid4
-from pytest import mark
-from re import match
 
 from adminapi.dataset import Query
 from fabric.api import env
+from fabric.network import disconnect_all
+from libvirt import VIR_DOMAIN_RUNNING
 
 from igvm.commands import (
     change_address,
@@ -46,11 +46,11 @@ from igvm.settings import (
     VG_NAME,
 )
 from igvm.utils import parse_size
-from fabric.network import disconnect_all
 
 basicConfig(level=INFO)
 env.update(COMMON_FABRIC_SETTINGS)
-env['user'] = 'igtesting'  # Enforce user for integration testing process
+environ['IGVM_SSH_USER'] = 'igtesting'  # Enforce user for integration testing
+env.user = 'igtesting'
 environ['IGVM_MODE'] = 'testing'
 
 # Configuration of VMs used for tests


### PR DESCRIPTION
When establishing a SSH connection to a hypervisor using libvirt via SSH
we should also check the local ssh config as for VMs using paramiko.
Additionally using environment variables to overwrite the settings for
integration is more consistent as we do it already for setting up IGVM.

- Do not abuse fabrics env dictionary but use environment variables
- Also check local ssh_config for SSH configuration