### PR TITLE
Enable Multiqueue Virtio for network interface

### DIFF
--- a/igvm/templates/domain.xml
+++ b/igvm/templates/domain.xml
@@ -54,6 +54,7 @@
 {% endif %}
       <virtualport type='openvswitch'/>
       <model type='virtio'/>
+      <driver name='vhost' queues='{{ num_cpu }}'/>
     </interface>
     <serial type='pty'>
       <target port='0'/>


### PR DESCRIPTION
The optional queues attribute controls the number of queues to be used for either Multiqueue virtio-net or vhost-user network interfaces. 
Each queue will potentially be handled by a different processor, resulting in **much higher throughput**.
On VMs to enable multi-queue need to execute:
ethtool -L eth0 combined N
To apply permanently add to /etc/network/interfaces:
up ethtool -L eth0 combined N

Where N should be less or equal to queue number in domail.xml

Partially resolves TECH-38074. 