### PR TITLE
Use hostnames instead of IPv4 addresses in Fabric

### DIFF
--- a/igvm/host.py
+++ b/igvm/host.py
@@ -66,7 +66,7 @@ class Host(object):
         settings = COMMON_FABRIC_SETTINGS.copy()
         settings.update({
             'abort_exception': RemoteCommandError,
-            'host_string': str(self.dataset_obj['intern_ip']),
+            'host_string': str(self.dataset_obj['hostname']),
         })
         settings.update(kwargs)
         return fabric.api.settings(*args, **settings)


### PR DESCRIPTION
I ran into a problem where one of my Hypervisors is IPv6 only and IGVM was still trying to connect to it using IPv4. 
This patch changes IGVM to use hostnames instead of hardcoded IPv4. 
I haven't done much testing on this, so please test it accordingly before merging. 