### PR TITLE
Speed up Hypervisor finding procedure

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -4,14 +4,15 @@ Copyright (c) 2018 InnoGames GmbH
 """
 
 import logging
-from os import environ
+from collections import OrderedDict
 from contextlib import contextmanager, ExitStack
+from ipaddress import ip_address
+from os import environ
 
 from adminapi.dataset import Query
 from adminapi.filters import Any, StartsWith, Contains
 from fabric.colors import green, red, white, yellow
 from fabric.network import disconnect_all
-from ipaddress import ip_address
 from jinja2 import Environment, PackageLoader
 from libvirt import libvirtError
 
@@ -33,7 +34,7 @@ from igvm.settings import (
     VM_ATTRIBUTES,
 )
 from igvm.transaction import Transaction
-from igvm.utils import parse_size
+from igvm.utils import parse_size, parallel
 from igvm.vm import VM
 
 log = logging.getLogger(__name__)
@@ -827,57 +828,66 @@ def _get_hypervisor(hostname, allow_reserved=False):
 def _get_best_hypervisor(vm, hypervisor_states, offline=False):
     hv_env = environ.get('IGVM_MODE', 'production')
 
+    # Get all (theoretically) possible HVs sorted by HV preferences
     hypervisors = (Hypervisor(o) for o in Query({
         'servertype': 'hypervisor',
         'environment': hv_env,
         'vlan_networks': vm.route_network,
         'state': Any(*hypervisor_states),
     }, HYPERVISOR_ATTRIBUTES))
+    hypervisors = sorted_hypervisors(HYPERVISOR_PREFERENCES, vm, hypervisors)
 
-    for hypervisor in sorted_hypervisors(
-        HYPERVISOR_PREFERENCES, vm, hypervisors
-    ):
-        # The actual resources are not checked during sorting for performance.
-        # We need to validate the hypervisor using the actual values before
-        # the final decision.
-        try:
-            hypervisor.acquire_lock()
-        except InvalidStateError as error:
-            log.warning(error)
-            continue
+    possible_hvs = OrderedDict()
+    for possible_hv in hypervisors:
+        possible_hvs[str(possible_hv)] = possible_hv
 
-        try:
-            hypervisor.check_vm(vm, offline)
-        except libvirtError as error:
-            hypervisor.release_lock()
-            log.warning(
-                'Preferred hypervisor "{}" is skipped: {}'.format(
-                    hypervisor, error)
-            )
-            continue
-        except HypervisorError as error:
-            hypervisor.release_lock()
-            log.warning(
-                'Preferred hypervisor "{}" is skipped: {}'.format(
-                    hypervisor, error)
-            )
-            continue
+    # Check all HVs in parallel. This will check live data on those HVs
+    # but without locking them. This allows us to do a real quick first
+    # filtering round. Below follows another one on the filtered HVs only.
+    results = parallel(
+        _check_vm,
+        identifiers=list(possible_hvs.keys()),
+        args=[
+            [possible_hv, vm, offline]
+            for possible_hv in possible_hvs.values()
+        ],
+    )
 
-        try:
-            yield hypervisor
-        finally:
-            hypervisor.release_lock()
-        break
-    else:
-        raise IGVMError(
-            (
-                'Cannot find hypervisor matching environment: {}, '
-                'states: {}, vlan_network: {}'
-            ).format(
-                hv_env, ', '.join(hypervisor_states),
-                vm.route_network,
-            )
+    # Remove unsupported HVs from the list
+    for checked_hv, success in results.items():
+        if not success:
+            possible_hvs.pop(checked_hv)
+
+    # No supported HV was found
+    not_found_err = IGVMError(
+        'Cannot find hypervisor matching environment: {}, '
+        'states: {}, vlan_network: {}, offline: {}'.format(
+            hv_env, ', '.join(hypervisor_states), vm.route_network, offline,
         )
+    )
+
+    if len(possible_hvs) == 0:
+        raise not_found_err
+
+    # Do another checking iteration, this time with HV locking
+    for possible_hv in possible_hvs.values():
+        try:
+            possible_hv.acquire_lock()
+        except InvalidStateError as e:
+            log.warning(e)
+            continue
+
+        if not _check_vm(possible_hv, vm, offline):
+            possible_hv.release_lock()
+            continue
+
+        try:
+            yield possible_hv
+            break
+        finally:
+            possible_hv.release_lock()
+    else:
+        raise not_found_err
 
 
 @contextmanager
@@ -894,3 +904,22 @@ def _check_attributes(vm):
     for attr, value in synced_attributes.items():
         if vm.dataset_obj[attr] != value:
             raise InconsistentAttributeError(vm, attr, value)
+
+
+def _check_vm(hv, vm, offline):
+    try:
+        hv.check_vm(vm, offline)
+
+        return True
+    except libvirtError as e:
+        log.warning(
+            'Preferred hypervisor "{}" is skipped: {}'.format(hv, e)
+        )
+
+        return False
+    except HypervisorError as e:
+        log.warning(
+            'Preferred hypervisor "{}" is skipped: {}'.format(hv, e)
+        )
+
+        return False

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -3,14 +3,15 @@
 Copyright (c) 2018 InnoGames GmbH
 """
 
-from contextlib import contextmanager
 import logging
 import math
+from contextlib import contextmanager
 from time import sleep
-
-from libvirt import VIR_DOMAIN_SHUTOFF
 from xml.etree import ElementTree
 
+from libvirt import VIR_DOMAIN_SHUTOFF
+
+from igvm.drbd import DRBD
 from igvm.exceptions import (
     ConfigError,
     HypervisorError,
@@ -18,7 +19,6 @@ from igvm.exceptions import (
     InvalidStateError,
     StorageError,
 )
-from igvm.drbd import DRBD
 from igvm.host import Host
 from igvm.kvm import (
     DomainProperties,
@@ -161,35 +161,10 @@ class Hypervisor(Host):
 
     def check_vm(self, vm, offline):
         """Check whether a VM can run on this hypervisor"""
-        if self.dataset_obj['state'] not in ['online', 'online_reserved']:
-            raise InvalidStateError(
-                'Hypervisor "{}" is not in online state ({}).'
-                .format(self.fqdn, self.dataset_obj['state'])
-            )
+        # Cheap checks should always be executed first to save time
+        # and fail early. Same goes for checks that are more likely to fail.
 
-        if self.vm_defined(vm):
-            raise HypervisorError(
-                'VM "{}" is already defined on "{}".'
-                .format(vm.fqdn, self.fqdn)
-            )
-
-        # Enough CPUs?
-        if vm.dataset_obj['num_cpu'] > self.dataset_obj['num_cpu']:
-            raise HypervisorError(
-                'Not enough CPUs. Destination Hypervisor has {0}, '
-                'but VM requires {1}.'
-                .format(self.dataset_obj['num_cpu'], vm.dataset_obj['num_cpu'])
-            )
-
-        # Enough memory?
-        free_mib = self.free_vm_memory()
-        if vm.dataset_obj['memory'] > free_mib:
-            raise HypervisorError(
-                'Not enough memory. '
-                'Destination Hypervisor has {:.2f} MiB but VM requires {} MiB '
-                .format(free_mib, vm.dataset_obj['memory'])
-            )
-
+        # Immediately check whether HV is even supported.
         if not offline:
             # Compatbile OS?
             os_pair = (vm.hypervisor.dataset_obj['os'], self.dataset_obj['os'])
@@ -215,6 +190,40 @@ class Hypervisor(Host):
                     .format(*hw_pair)
                 )
 
+        # HV in supported state?
+        if self.dataset_obj['state'] not in ['online', 'online_reserved']:
+            raise InvalidStateError(
+                'Hypervisor "{}" is not in online state ({}).'
+                .format(self.fqdn, self.dataset_obj['state'])
+            )
+
+        # Enough CPUs?
+        if vm.dataset_obj['num_cpu'] > self.dataset_obj['num_cpu']:
+            raise HypervisorError(
+                'Not enough CPUs. Destination Hypervisor has {0}, '
+                'but VM requires {1}.'
+                .format(self.dataset_obj['num_cpu'], vm.dataset_obj['num_cpu'])
+            )
+
+        # Proper VLAN?
+        if not self.get_vlan_network(vm.dataset_obj['intern_ip']):
+            raise HypervisorError(
+                'Hypervisor "{}" does not support route_network "{}".'
+                .format(self.fqdn, vm.route_network)
+            )
+
+        # Those checks below all require libvirt connection,
+        # so execute them last to avoid unnecessary overhead if possible.
+
+        # Enough memory?
+        free_mib = self.free_vm_memory()
+        if vm.dataset_obj['memory'] > free_mib:
+            raise HypervisorError(
+                'Not enough memory. '
+                'Destination Hypervisor has {:.2f} MiB but VM requires {} MiB '
+                .format(free_mib, vm.dataset_obj['memory'])
+            )
+
         # Enough disk?
         free_disk_space = self.get_free_disk_size_gib()
         vm_disk_size = float(vm.dataset_obj['disk_size_gib'])
@@ -225,11 +234,11 @@ class Hypervisor(Host):
                 .format(VG_NAME, RESERVED_DISK[self.get_storage_type()])
             )
 
-        # Proper VLAN?
-        if not self.get_vlan_network(vm.dataset_obj['intern_ip']):
+        # VM already defined? Least likely, if at all.
+        if self.vm_defined(vm):
             raise HypervisorError(
-                'Hypervisor "{}" does not support route_network "{}".'
-                .format(self.fqdn, vm.route_network)
+                'VM "{}" is already defined on "{}".'
+                .format(vm.fqdn, self.fqdn)
             )
 
     def define_vm(self, vm, transaction=None):


### PR DESCRIPTION
Dramatically speed up the process by doing an additional HV filtering
round based on real data before HVs are locked in the next round to
yield it (locked).
Reordering of HV checks in order to execute cheap checks first and
expensive ones last. This can potentially reduce a lot of wasted time.