### PR TITLE
Cleanup connections that were used during Hypervisor finding

### DIFF
--- a/igvm/libvirt.py
+++ b/igvm/libvirt.py
@@ -35,11 +35,19 @@ def get_virtconn(fqdn):
     return _conns[fqdn]
 
 
+def close_virtconn(fqdn):
+    if fqdn not in _conns:
+        return
+
+    conn = _conns[fqdn]
+    try:
+        conn.close()
+    except libvirtError:
+        pass
+
+    del _conns[fqdn]
+
+
 def close_virtconns():
     for fqdn in list(_conns.keys()):
-        conn = _conns[fqdn]
-        try:
-            conn.close()
-        except libvirtError:
-            pass
-        del _conns[fqdn]
+        close_virtconn(fqdn)


### PR DESCRIPTION
After checking all hypervisors in parallel we need to clean the connections up again.
Otherwise we have idling connections which put pressure on the file limit and the SSH agent.