### PR TITLE
Fix typo on ca_host variable name

### DIFF
--- a/igvm/puppet.py
+++ b/igvm/puppet.py
@@ -47,8 +47,7 @@ def clean_cert(vm, user=None):
         ]
         random.shuffle(ca_hosts)
 
-        ca_hosts = ca_hosts[0]
-
+        ca_host = ca_hosts[0]
     with settings(
         host_string=ca_host,
         user=user,


### PR DESCRIPTION
There was an extra S in the ca_host variable name that was breaking the `build --rebuild` command for VMs that have a loadbalancer as ca_host instead of a VM.