### PR TITLE
WIP: Add certclean on vm build rollback

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -336,7 +336,7 @@ def vm_build(vm_hostname, run_puppet=True, debug_puppet=False, postboot=None,
                 run_puppet=run_puppet,
                 debug_puppet=debug_puppet,
                 postboot=postboot,
-                clean_cert=rebuild,
+                cleanup_cert=rebuild,
             )
         else:
             raise NotImplementedError(

--- a/igvm/puppet.py
+++ b/igvm/puppet.py
@@ -13,11 +13,11 @@ from fabric.operations import sudo
 from adminapi.dataset import Query
 from igvm.exceptions import ConfigError
 from igvm.settings import COMMON_FABRIC_SETTINGS
+import logging
 
-def clean_cert(vm, user=None):
-    if 'user' in COMMON_FABRIC_SETTINGS:
-        user = COMMON_FABRIC_SETTINGS['user']
+log = logging.getLogger(__name__)
 
+def get_puppet_ca(vm):
     puppet_ca_type = Query(
         {
             'hostname': vm['puppet_ca'],
@@ -33,7 +33,7 @@ def clean_cert(vm, user=None):
         )
 
     if puppet_ca_type == 'vm':
-        ca_host = vm['puppet_ca']
+        return vm['puppet_ca']
     else:
         ca_query = Query(
             {'domain': vm['puppet_ca']},
@@ -47,7 +47,13 @@ def clean_cert(vm, user=None):
         ]
         random.shuffle(ca_hosts)
 
-        ca_host = ca_hosts[0]
+        return ca_hosts[0]
+
+def clean_cert(vm, user=None):
+    if 'user' in COMMON_FABRIC_SETTINGS:
+        user = COMMON_FABRIC_SETTINGS['user']
+    ca_host = get_puppet_ca(vm)
+    log.info("Cleaning puppet for {} on {}".format(vm['hostname'], ca_host))
     with settings(
         host_string=ca_host,
         user=user,
@@ -56,9 +62,11 @@ def clean_cert(vm, user=None):
         version = sudo('/usr/bin/puppet --version', shell=False, quiet=True)
 
         if not version.succeeded or int(version.split('.')[0]) < 6:
-            sudo('/usr/bin/puppet cert clean {}'.format(
+            result = sudo('/usr/bin/puppet cert clean {}'.format(
                 vm['hostname'],
             ), shell=False)
+            log.info(result.stdout)
+            log.info(result.stderr)
         else:
             sudo(
                 '/opt/puppetlabs/bin/puppetserver ca clean '

--- a/igvm/puppet.py
+++ b/igvm/puppet.py
@@ -53,7 +53,7 @@ def clean_cert(vm, user=None):
     if 'user' in COMMON_FABRIC_SETTINGS:
         user = COMMON_FABRIC_SETTINGS['user']
     ca_host = get_puppet_ca(vm)
-    log.info("Cleaning puppet for {} on {}".format(vm['hostname'], ca_host))
+    log.info("Cleaning puppet certificate for {} on {}".format(vm['hostname'], ca_host))
     with settings(
         host_string=ca_host,
         user=user,
@@ -62,11 +62,9 @@ def clean_cert(vm, user=None):
         version = sudo('/usr/bin/puppet --version', shell=False, quiet=True)
 
         if not version.succeeded or int(version.split('.')[0]) < 6:
-            result = sudo('/usr/bin/puppet cert clean {}'.format(
+            sudo('/usr/bin/puppet cert clean {}'.format(
                 vm['hostname'],
             ), shell=False)
-            log.info(result.stdout)
-            log.info(result.stderr)
         else:
             sudo(
                 '/opt/puppetlabs/bin/puppetserver ca clean '

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -447,9 +447,8 @@ class VM(Host):
 
         with Transaction() as transaction:
             # Clean up the certificate if the build fails for any reason
-            # TODO: FIND OUT WHY THIS DOESNT WORK
-            transaction.on_rollback('Inform about cert clean', log.info, 'Rolling back for vm {}'.format(self.dataset_obj['hostname']))
             transaction.on_rollback('Clean cert', clean_cert, self.dataset_obj)
+
             # Perform operations on the hypervisor
             self.hypervisor.create_vm_storage(self, transaction)
             mount_path = self.hypervisor.format_vm_storage(self, transaction)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,6 @@
 Copyright (c) 2018 InnoGames GmbH
 """
 from __future__ import print_function
-import logging
 from logging import INFO, basicConfig
 from os import environ
 from pipes import quote
@@ -53,7 +52,6 @@ from igvm.puppet import (
 )
 from igvm.utils import parse_size
 
-logger = logging.getLogger(__name__)
 
 basicConfig(level=INFO)
 env.update(COMMON_FABRIC_SETTINGS)
@@ -318,21 +316,6 @@ class IGVMTest(TestCase):
                         'test ! -b /dev/{}/{}'.format(VG_NAME, self.uid_name)
                     )
 
-    def check_vm_cert_cleaned(self, retries=5):
-        vm = Query({'hostname': VM_HOSTNAME}, ['hostname', 'puppet_ca']).get()
-        puppet_ca = get_puppet_ca(vm)
-
-        with settings(host_string=puppet_ca, warn_only=True):
-            for i in range(retries):
-                result = sudo('puppet cert verify {}'.format(VM_HOSTNAME))
-
-                if result.return_code == 24:
-                    break
-
-        logger.info('Tried verify {} times'.format(i + 1))
-
-        self.assertEqual(24, result.return_code)
-
 
 class BuildTest(IGVMTest):
     """Test many possible VM building scenarios"""
@@ -382,7 +365,6 @@ class BuildTest(IGVMTest):
             vm_build(VM_HOSTNAME)
 
         self.check_vm_absent()
-        self.check_vm_cert_cleaned()
 
     def test_rebuild(self):
         vm_build(VM_HOSTNAME)


### PR DESCRIPTION
We need to clean up certs when building a vm fails, because we don't clean up on build anymore.
This commit adds that, as well as a test for cert cleaning having taken place.