### PR TITLE
feat(commands): Add command to define VM

### DIFF
--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -24,7 +24,7 @@ from igvm.commands import (
     vm_restart,
     vm_start,
     vm_stop,
-    vm_sync,
+    vm_sync, vm_define,
 )
 from igvm.libvirt import close_virtconns
 
@@ -394,6 +394,13 @@ def parse_args():
         nargs='*',
         help='Migrate VMs matching the given serveradmin function offline',
     )
+
+    subparser = subparsers.add_parser(
+        'define',
+        description=vm_define.__doc__,
+    )
+    subparser.set_defaults(func=vm_define)
+    subparser.add_argument('vm_hostname', help='Hostname of the guest system')
 
     return vars(top_parser.parse_args())
 

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -636,6 +636,27 @@ def vm_sync(vm_hostname):
             )
 
 
+def vm_define(vm_hostname):
+    """Define VM on hypervisor
+
+    This command executes necessary code to just define the VM aka create the
+    domain.xml for libvirt. It is a convenience command to restore a domain
+    in case you lost your SSH session while the domain was not defined.
+
+    :param: vm_hostname: hostname of VM
+    """
+
+    vm_dataset_obj = Query({'hostname': vm_hostname}, VM_ATTRIBUTES).get()
+    hv = Hypervisor(vm_dataset_obj['hypervisor'])
+    vm = VM(vm_dataset_obj, hv)
+
+    hv.define_vm(vm)
+    vm.start()
+
+    log.info('VM {} defined and booted on {}'.format(
+        vm_hostname, vm_dataset_obj['hypervisor']['hostname']))
+
+
 @with_fabric_settings  # NOQA: C901
 def host_info(vm_hostname):
     """Extract runtime information about a VM

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,6 +21,7 @@ from igvm.commands import (
     mem_set,
     vcpu_set,
     vm_build,
+    vm_define,
     vm_delete,
     vm_migrate,
     vm_restart,
@@ -42,8 +43,10 @@ from igvm.settings import (
     HYPERVISOR_CPU_THRESHOLDS,
     KVM_HWMODEL_TO_CPUMODEL,
     VG_NAME,
+    VM_ATTRIBUTES
 )
 from igvm.utils import parse_size
+from igvm.vm import VM
 from tests import VM_HOSTNAME, VM_NET
 from tests.conftest import (
     clean_all,
@@ -493,6 +496,19 @@ class CommandTest(IGVMTest):
                 list(dest_hv_obj['igvm_migration_log']),
                 ['{} +{}'.format(timestamp, round(cpu_usage_vm_dest))]
             )
+
+    def test_vm_define(self):
+        vm_dataset_obj = Query({'hostname': VM_HOSTNAME}, VM_ATTRIBUTES).get()
+
+        hv = Hypervisor(vm_dataset_obj['hypervisor'])
+        vm = VM(vm_dataset_obj, hv)
+
+        vm_stop(VM_HOSTNAME)
+        hv.undefine_vm(vm, keep_storage=True)
+
+        self.check_vm_absent()
+        vm_define(VM_HOSTNAME)
+        self.check_vm_present()
 
 
 class MigrationTest(IGVMTest):


### PR DESCRIPTION
It can happen that ones SSH connection is interrupted when doing
critical actions where the VM is not defined anymore (e.g. rename). In
such as case one has to quickly redefine the VM and boot it.