### PR TITLE
feat(migration): Only migrate if predicted CPU usage is below threshold

### DIFF
--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -15,6 +15,7 @@ from igvm.hypervisor_preferences import (
     HashDifference,
     HypervisorAttributeValue,
     HypervisorAttributeValueLimit,
+    HypervisorCpuUsageLimit,
     InsufficientResource,
     OtherVMs,
     OverAllocation,
@@ -113,6 +114,7 @@ except KeyError:
 IMAGE_PATH = '/tmp'
 
 HYPERVISOR_ATTRIBUTES = [
+    'cpu_perffactor',
     'cpu_util_pct',
     'cpu_util_vm_pct',
     'hardware_model',
@@ -171,6 +173,7 @@ VM_ATTRIBUTES = [
     'igvm_locked',
     'intern_ip',
     'io_weight',
+    'load_99',
     'mac',
     'memory',
     'num_cpu',
@@ -290,6 +293,17 @@ AWS_CONFIG = [
     }
 ]
 
+# The loadtested CPU usage thresholds per hypervisor hardware model,
+# before we are experiencing reasonable steal time.
+HYPERVISOR_CPU_THRESHOLDS = {
+    'Dell_M610': 50,  # untested
+    'Dell_M710': 50,  # untested
+    'Dell_M620': 60,
+    'Dell_M630': 70,
+    'Dell_M640': 75,
+    'Dell_R6515': 50,
+}
+
 # The list is ordered from more important to less important.  The next
 # preference is only going to be checked when the previous ones return all
 # the same values.
@@ -309,6 +323,14 @@ HYPERVISOR_PREFERENCES = [
     # for the given time_range and dismisses it as target when it is over
     # the value of threshold.
     HypervisorAttributeValueLimit('cpu_util_vm_pct', 45),
+    # Calculates the performance_value of the given VM, which is comparable
+    # across hypervisor hardware models. It uses this value to predict the
+    # CPU usage of the VM on the destination hypervisor and dismisses all
+    # targets with a value above the threshold.
+    HypervisorCpuUsageLimit(
+        'hardware_model',
+        HYPERVISOR_CPU_THRESHOLDS,
+    ),
     # Don't migrate two redundant VMs together
     OtherVMs([
         'project',

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -826,3 +826,26 @@ class VM(Host):
         )
 
         return sync_values
+
+    def vm_performance_value(self) -> float:
+        """VM Performance Value
+
+        Calculate the performance_value of the VM by multiplying the
+        load_99 of the VM with the cpu_perffactor of the HV.
+        Use the num_cpu instead of load_99 value, if load_99 > num_cpu.
+
+        :return: performance_value of VM as float
+        """
+
+        # We can't save floats in graphite cache of serveradmin and therefore
+        # divide it by the value we multiplied it before.
+        vm_load_99 = self.dataset_obj['load_99'] / 1000
+        hv_perffactor_src = self.hypervisor.dataset_obj[
+                                'cpu_perffactor'] / 1000
+        vm_num_cpu = self.dataset_obj['num_cpu']
+
+        vm_performance_value = (
+            vm_load_99 if vm_load_99 < vm_num_cpu else vm_num_cpu
+        ) * hv_perffactor_src
+
+        return float(vm_performance_value)


### PR DESCRIPTION
The calculated performance_value of the VM is used to predict
the CPU usage done by the VM on the destination hypervisor.
If the hypervisor then gets above the loadtested threshold,
which would lead to steal time, we dismiss this HV as a candidate.