### PR TITLE
Fix lost exceptions

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,7 +23,7 @@ else:
 if environ.get('PYTEST_XDIST_WORKER_COUNT'):
     PYTEST_XDIST_WORKER_COUNT = int(environ['PYTEST_XDIST_WORKER_COUNT'])
 else:
-    PYTEST_XDIST_WORKER_COUNT = 0
+    PYTEST_XDIST_WORKER_COUNT = 1
 
 
 VM_NET = 'igvm-net-{}-aw.test.ig.local'.format(JENKINS_EXECUTOR)


### PR DESCRIPTION
The actual fix is moving the "yield" out of the loop.
This prevents a StopIteration exception from being raised when the
generator is interrupted. When a StopIteration exception is raised,
the ExitStack tries to do some black magic and in fact drops the
exception together with any original exception that was passed
to the ExitStack.
By getting rid of that code path, the exception can be properly passed
to any outside caller and handle it properly.