### PR TITLE
feat(migration): Add migration log for CPU usage calculation

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -432,6 +432,23 @@ def vm_migrate(vm_hostname=None, vm_object=None, hypervisor_hostname=None,
                 _vm.start(transaction=transaction)
             _vm.reset_state()
 
+            # Add migration log entries to hypervisor and previous_hypervisor
+            hypervisor.hv_add_migration_log(_vm, '+')
+            transaction.on_rollback(
+                'reset hypervisor log',
+                hypervisor.hv_add_migration_log,
+                _vm,
+                '-',
+            )
+
+            previous_hypervisor.hv_add_migration_log(_vm, '-')
+            transaction.on_rollback(
+                'reset previous hypervisor log',
+                previous_hypervisor.hv_add_migration_log,
+                _vm,
+                '+',
+            )
+
             # Update Serveradmin
             _vm.dataset_obj['hypervisor'] = hypervisor.dataset_obj['hostname']
             _vm.dataset_obj.commit()

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -122,6 +122,7 @@ HYPERVISOR_ATTRIBUTES = [
     'igvm_locked',
     'intern_ip',
     'iops_avg',
+    'igvm_migration_log',
     'libvirt_memory_total_gib',
     'libvirt_memory_used_gib',
     'libvirt_pool_total_gib',


### PR DESCRIPTION
Since our CPU usage values of our Hypervisors are only updated once
every three hours, we might migrate multiple VMs to the same HV.

To solve this, we can integrate an igvm_migration_log to Serveradmin which will 
get updated with every migration. We will delete the log entry after
24 hours when the graphite data in Serveradmin is correct again.
We will take this migration log into account during selecting the best HV.