### PR TITLE
feat(build/aws): Spawn VM with a fitting vm_type

### DIFF
--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -199,13 +199,13 @@ AWS_RETURN_CODES = {
     'stopped': 80,
 }
 
+AWS_INSTANCES_OVERVIEW_URL = 'https://www.ec2instances.info/instances.json'
+AWS_INSTANCES_OVERVIEW_FILE = '/tmp/AWS_INSTANCES_OVERVIEW_FILE.json'
+AWS_INSTANCES_OVERVIEW_FILE_etag = '/tmp/AWS_INSTANCES_OVERVIEW_FILE.etag'
+AWS_ECU_FACTOR = 7
+
 AWS_CONFIG = [
     {
-        # TODO: remove this puppet config and use internal project based puppet
-        'puppet': {
-            'ca_addr': '212.53.146.132',
-            'master_addr': '212.53.146.131',
-        },
         'apt': [
             {
                 'name': 'innogames_stable',


### PR DESCRIPTION
We can't ensure, that the commited aws_instance_type in SA
is still available in the corresponding region of AWS.
To avoid breaking builds we use our new vm_performance_factor
to get a list of fitting vm_types in AWS, which have at least -25%
or at max +25% the performance of the original VM.
We try the next fitting one, if the one before is not available
anymore.