### PR TITLE
Remove team attribute, it's gone from Serveradmin

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -114,7 +114,6 @@ class IGVMTest(TestCase):
             'int:innogames:stable',
         ]
         self.vm_obj['state'] = 'online'
-        self.vm_obj['team'] = 'test'
         self.vm_obj.commit()
 
         self.uid_name = '{}_{}'.format(


### PR DESCRIPTION
Make igvm integration tests great again!