### PR TITLE
feat(build/migrate): Add HV env preference and enforce-env parameter

### DIFF
--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -177,6 +177,12 @@ def parse_args():
             ' operator to shut down VM.'
         ),
     )
+    subparser.add_argument(
+        '--enforce-vm-env',
+        dest='enforce_vm_env',
+        action='store_true',
+        help='Build or migrate VM only to a HV with the same environment of VM'
+    )
 
     subparser = subparsers.add_parser(
         'change-address',

--- a/igvm/hypervisor_preferences.py
+++ b/igvm/hypervisor_preferences.py
@@ -168,6 +168,30 @@ class HypervisorCpuUsageLimit():
         )
 
 
+class HypervisorEnvironmentValue():
+    """Check if the environment of the hypervisor fits with the VM env.
+
+    Make any hypervisor less likely chosen, which would have a different
+    environment.
+    """
+    def __init__(self, hv_env: str):
+        self.hv_env = hv_env
+
+    def __repr__(self):
+        args = repr(self.hv_env)
+
+        return '{}({})'.format(type(self).__name__, args)
+
+    def __call__(self, vm, hv) -> bool:
+        hypervisor_env = hv.dataset_obj[self.hv_env]
+        vm_env = vm.dataset_obj['environment']
+
+        if hypervisor_env == vm_env:
+            return True
+
+        return False
+
+
 class OverAllocation(object):
     """Check for an attribute being over allocated than the current one"""
     def __init__(self, attribute):

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -16,6 +16,7 @@ from igvm.hypervisor_preferences import (
     HypervisorAttributeValue,
     HypervisorAttributeValueLimit,
     HypervisorCpuUsageLimit,
+    HypervisorEnvironmentValue,
     InsufficientResource,
     OtherVMs,
     OverAllocation,
@@ -123,6 +124,7 @@ HYPERVISOR_ATTRIBUTES = [
     'cpu_perffactor',
     'cpu_util_pct',
     'cpu_util_vm_pct',
+    'environment',
     'hardware_model',
     'hostname',
     'igvm_locked',
@@ -332,6 +334,9 @@ HYPERVISOR_PREFERENCES = [
         multiplier=1024,
         reserved=2048,
     ),
+    # Compares the environment of the VM with the environment of the
+    # hypervisor. It makes hypervisors of different envs less likely chosen.
+    HypervisorEnvironmentValue('environment'),
     # Checks the maximum vCPU usage (95 percentile) of the given hypervisor
     # for the given time_range and dismisses it as target when it is over
     # the value of threshold.


### PR DESCRIPTION
We want to prefer hypervisors of the same environment as build/migration destination. Since not all projects have testing hypervisors, this is just a preference, which will not affect the hypervisor selection. Additionally there is also a parameter now, to be able to enforce it for builds/migrations.