### PR TITLE
Restore fix for vm_rename function

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -780,7 +780,13 @@ def vm_rename(vm_hostname, new_hostname, offline=False):
         if vm.dataset_obj['datacenter_type'] != 'kvm.dct':
             raise NotImplementedError(
                 'This operation is not yet supported for {}'.format(
-                    vm.dataset_obj['datacenter_type'])
+                    vm.dataset_obj['datacenter_type']
+                )
+            )
+
+        if vm.dataset_obj['puppet_disabled']:
+            raise ConfigError(
+                'Rename command only works with Puppet enabled'
             )
 
         _check_defined(vm)

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -160,6 +160,23 @@ class VM(Host):
         """Resizes the host memory."""
         self.hypervisor.vm_set_memory(self, memory)
 
+    def set_hostname(self, new_hostname, transaction=None):
+        """Changes the hostname of a VM"""
+        self.previous_hostname = self.dataset_obj['hostname']
+
+        self.dataset_obj['hostname'] = new_hostname
+        self.check_serveradmin_config()
+
+        self.dataset_obj.commit()
+
+        if transaction:
+            transaction.on_rollback('revert_hostname', self.revert_hostname)
+
+    def revert_hostname(self):
+        """Revert the VM name to the previously defined name"""
+        if hasattr(self, 'previous_hostname'):
+            self.set_hostname(self.previous_hostname)
+
     def check_serveradmin_config(self):
         """Validate relevant Serveradmin attributes"""
 
@@ -610,29 +627,23 @@ class VM(Host):
 
     def rename(self, new_hostname):
         """Rename the VM"""
-        self.dataset_obj['hostname'] = new_hostname
-        self.check_serveradmin_config()
-
-        fd = BytesIO()
-        fd.write(bytes(new_hostname, 'utf-8'))
-        self.put('/etc/hostname', fd)
-        self.put('/etc/mailname', fd)
-
-        hosts_file = [
-            line
-            for line in self.run('cat /etc/hosts').splitlines()
-            if not line.startswith(str(self.dataset_obj['intern_ip']))
-        ]
-        hosts_file.append('{0}\t{1}'.format(
-            self.dataset_obj['intern_ip'], new_hostname
-        ))
-        self.run("echo '{0}' > /etc/hosts".format('\n'.join(hosts_file)))
-
         with Transaction() as transaction:
-            self.shutdown(transaction=transaction)
-            self.hypervisor.redefine_vm(self, new_fqdn=new_hostname)
+            self.set_hostname(new_hostname, transaction=transaction)
+            self.check_serveradmin_config()
 
-            self.dataset_obj.commit()
+            self.shutdown(transaction=transaction)
+
+            self.hypervisor.redefine_vm(self, new_fqdn=new_hostname)
+            log.warning(
+                'Domain redefinition cannot be rolled back properly. Your '
+                'domain is still defined with the new name.'
+            )
+
+            self.hypervisor.mount_vm_storage(self, transaction=transaction)
+
+            self.run_puppet()
+
+            self.hypervisor.umount_vm_storage(self)
 
             self.start(transaction=transaction)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,7 +32,10 @@ VM_HOSTNAME = VM_HOSTNAME_PATTERN.format(
     JENKINS_EXECUTOR,
     PYTEST_XDIST_WORKER,
 )
-VM_HOSTNAME_RENAMED = 'renamed-' + VM_HOSTNAME
+VM_HOSTNAME_RENAMED = 'igvm-vm-rename-{}-{}.test.ig.local'.format(
+    JENKINS_EXECUTOR,
+    PYTEST_XDIST_WORKER,
+)
 
 # Amount of time after which the igvm_locked status should be cleared
 IGVM_LOCKED_TIMEOUT = timedelta(minutes=15)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,6 +32,7 @@ VM_HOSTNAME = VM_HOSTNAME_PATTERN.format(
     JENKINS_EXECUTOR,
     PYTEST_XDIST_WORKER,
 )
+VM_HOSTNAME_RENAMED = 'renamed-' + VM_HOSTNAME
 
 # Amount of time after which the igvm_locked status should be cleared
 IGVM_LOCKED_TIMEOUT = timedelta(minutes=15)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -520,7 +520,12 @@ class CommandTest(IGVMTest):
         """
 
         vm_rename(VM_HOSTNAME, new_hostname=VM_HOSTNAME_RENAMED, offline=True)
+        # If this tests fails you must manually remove the VM from the HVs
         self.check_vm_present(VM_HOSTNAME_RENAMED)
+
+        # Rename VM back to its original afterwards to make sure the cleanup
+        # task of IGVM can delete it.
+        vm_rename(VM_HOSTNAME_RENAMED, new_hostname=VM_HOSTNAME, offline=True)
 
 
 class MigrationTest(IGVMTest):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,7 +9,9 @@ from os import environ
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
-from adminapi.dataset import Query, Any
+from adminapi.dataset import Query
+from adminapi.filters import Any
+
 from fabric.api import env
 from fabric.network import disconnect_all
 
@@ -24,6 +26,7 @@ from igvm.commands import (
     vm_define,
     vm_delete,
     vm_migrate,
+    vm_rename,
     vm_restart,
     vm_start,
     vm_stop,
@@ -47,7 +50,7 @@ from igvm.settings import (
 )
 from igvm.utils import parse_size
 from igvm.vm import VM
-from tests import VM_HOSTNAME, VM_NET
+from tests import VM_HOSTNAME, VM_HOSTNAME_RENAMED, VM_NET
 from tests.conftest import (
     clean_all,
     cmd,
@@ -131,9 +134,9 @@ class IGVMTest(TestCase):
         clean_cert(self.vm_obj)
         clean_all(self.route_network, VM_HOSTNAME)
 
-    def check_vm_present(self):
+    def check_vm_present(self, vm_name=VM_HOSTNAME):
         # Operate on fresh object
-        with _get_vm(VM_HOSTNAME) as vm:
+        with _get_vm(vm_name) as vm:
             for hv in self.hvs:
                 if hv.dataset_obj['hostname'] == vm.dataset_obj['hypervisor']:
                     # Is it on correct HV?
@@ -151,9 +154,9 @@ class IGVMTest(TestCase):
             self.assertEqual(fqdn, vm.fqdn)
             self.assertEqual(vm.dataset_obj.is_dirty(), False)
 
-    def check_vm_absent(self, hv_name=None):
+    def check_vm_absent(self, vm_name=VM_HOSTNAME, hv_name=None):
         # Operate on fresh object
-        with _get_vm(VM_HOSTNAME, allow_retired=True) as vm:
+        with _get_vm(vm_name, allow_retired=True) as vm:
             if not hv_name:
                 hv_name = vm.dataset_obj['hypervisor']
 
@@ -508,6 +511,16 @@ class CommandTest(IGVMTest):
         self.check_vm_absent()
         vm_define(VM_HOSTNAME)
         self.check_vm_present()
+
+    def test_vm_rename(self):
+        """Test vm_rename
+
+        Make sure renaming a VM works as expected without breaking while
+        runtime.
+        """
+
+        vm_rename(VM_HOSTNAME, new_hostname=VM_HOSTNAME_RENAMED, offline=True)
+        self.check_vm_present(VM_HOSTNAME_RENAMED)
 
 
 class MigrationTest(IGVMTest):


### PR DESCRIPTION
The added test for the vm_rename fix in https://github.com/innogames/igvm/pull/142 introduced a bug where the cleanup task failed to delete the renamed VMs when starting the tests which only became visible in follow up tests.

This PR brings back the origin fix for the vm_rename and a work around to allow the cleanup task to delete the VMs.