### PR TITLE
Fix KeyError in _get_best_hypervisor exception

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -959,12 +959,9 @@ def _get_best_hypervisor(
     if not found_hv:
         # No supported HV was found
         raise IGVMError(
-            'Cannot find hypervisor matching environment: {}, '
-            'states: {}, vlan_network: {}, offline: {}'.format(
-                hv_filter['environment'],
-                ', '.join(hypervisor_states), vm.route_network, offline,
-            )
-        )
+            'Automatically finding the best Hypervisor failed! '
+            'Can not find a suitable hypervisor with the preferences and '
+            'the Query: {}'.format(hv_filter))
 
     # Yield the hypervisor locked for working on it
     try:


### PR DESCRIPTION
Rephrase IGVMError raised when not Hypervisor can be found and print
complete Query filter to avoid future KeyErrors and show all infos.