### PR TITLE
Use hostname of Serveradmin object to clean up

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,11 +47,11 @@ def clean_all(route_network, vm_hostname=None):
 
     # If a VM hostname is given, only that will be cleaned from HVs.
     if vm_hostname is None:
-        pattern = '^([0-9]+_)?{}$'.format(
+        pattern = '^([0-9]+_)?(vm-rename-)?{}$'.format(
             VM_HOSTNAME_PATTERN.format(JENKINS_EXECUTOR, '[0-9]+'),
         )
     else:
-        pattern = '^([0-9]+_)?{}$'.format(vm_hostname)
+        pattern = '^([0-9]+_)?(vm-rename-)?{}$'.format(vm_hostname)
 
     # Clean HVs one by one.
     for hv in hvs:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,9 +11,9 @@ from unittest import TestCase
 
 from adminapi.dataset import Query
 from adminapi.filters import Any
-
 from fabric.api import env
 from fabric.network import disconnect_all
+from mock import patch
 
 from igvm.commands import (
     _get_vm,
@@ -50,13 +50,12 @@ from igvm.settings import (
 )
 from igvm.utils import parse_size
 from igvm.vm import VM
-from tests import VM_HOSTNAME, VM_HOSTNAME_RENAMED, VM_NET
+from tests import VM_HOSTNAME, VM_NET
 from tests.conftest import (
     clean_all,
     cmd,
     get_next_address,
 )
-from mock import patch
 
 basicConfig(level=INFO)
 env.update(COMMON_FABRIC_SETTINGS)
@@ -519,13 +518,10 @@ class CommandTest(IGVMTest):
         runtime.
         """
 
-        vm_rename(VM_HOSTNAME, new_hostname=VM_HOSTNAME_RENAMED, offline=True)
-        # If this tests fails you must manually remove the VM from the HVs
-        self.check_vm_present(VM_HOSTNAME_RENAMED)
+        new_name = '{}-{}'.format('vm-rename', VM_HOSTNAME)
 
-        # Rename VM back to its original afterwards to make sure the cleanup
-        # task of IGVM can delete it.
-        vm_rename(VM_HOSTNAME_RENAMED, new_hostname=VM_HOSTNAME, offline=True)
+        vm_rename(VM_HOSTNAME, new_hostname=new_name, offline=True)
+        self.check_vm_present(VM_HOSTNAME)
 
 
 class MigrationTest(IGVMTest):


### PR DESCRIPTION
The hostname might change in the tests (e.g. vm_rename) so we better use
the hostname from the VMs Serveradmin object to clean up stuff after the
test is done.