### PR TITLE
Rework HV selection algorithm

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -1,6 +1,6 @@
 """igvm - Command Routines
 
-Copyright (c) 2018 InnoGames GmbH
+Copyright (c) 2021 InnoGames GmbH
 """
 
 import logging

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -27,7 +27,7 @@ from igvm.exceptions import (
 )
 from igvm.host import with_fabric_settings
 from igvm.hypervisor import Hypervisor
-from igvm.hypervisor_preferences import sorted_hypervisors
+from igvm.hypervisor_preferences import sort_by_preference
 from igvm.puppet import clean_cert
 from igvm.settings import (
     AWS_CONFIG,
@@ -960,7 +960,7 @@ def _get_best_hypervisor(
     # Get all (theoretically) possible HVs sorted by HV preferences
     hypervisors = (Hypervisor(o) for o in
                    Query(hv_filter, HYPERVISOR_ATTRIBUTES))
-    hypervisors = sorted_hypervisors(HYPERVISOR_PREFERENCES, vm, hypervisors)
+    hypervisors = sort_by_preference(vm, HYPERVISOR_PREFERENCES, hypervisors)
 
     possible_hvs = OrderedDict()
     for possible_hv in hypervisors:

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -1024,6 +1024,7 @@ def _get_best_hypervisor(
 
     # Yield the hypervisor locked for working on it
     try:
+        log.info('Picked {} as destination Hypervisor'.format(str(found_hv)))
         yield found_hv
     finally:
         found_hv.release_lock()

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -1091,6 +1091,22 @@ class Hypervisor(Host):
             self.cpu_usage_of_recent_migrations(),
         ])
 
+        # TODO: The sum of estimated CPU usage can be negative because
+        #       cpu_usage_of_recent_migrations() can be negative.
+        #       Make this more stable and account for this discrepancy.
+        #       I.e. some if not all of the inputs are wrong!
+        if cpu_usage < 0:
+            log.error(
+                'Estimated CPU usage for Hypervisor "{}" and VM "{}" is '
+                'negative! Beware that this can lead to wrong '
+                'assumptions! Setting to zero!'.format(
+                    str(self),
+                    str(vm),
+                )
+            )
+
+            cpu_usage = max(0, cpu_usage)
+
         return float(cpu_usage)
 
     def cpu_usage_of_recent_migrations(self) -> int:

--- a/igvm/hypervisor_preferences.py
+++ b/igvm/hypervisor_preferences.py
@@ -348,13 +348,17 @@ class PreferenceEvaluator:
             # We expect normalized values from 0 - 1.
             if result < 0. or result > 1.:
                 raise ValueError(
-                    'Preference must be expressed in a 0.0 - 1.0 range, '
-                    '{} given.'.format(result)
+                    'Preference "{}" for Hypervisor "{}" must be expressed '
+                    'in a 0.0 - 1.0 range, {} given.'.format(
+                        str(pref),
+                        str(hv),
+                        result,
+                    )
                 )
 
             # Add up the individual preference scores.
             if result > 0.:
-                log.debug('Preference {} matches with score {:.4f}.'.format(
+                log.debug('Preference "{}" matches with score {:.4f}.'.format(
                     str(pref),
                     result,
                 ))

--- a/igvm/hypervisor_preferences.py
+++ b/igvm/hypervisor_preferences.py
@@ -59,6 +59,8 @@ class InsufficientResource(HypervisorPreference):
     def get_score(self, vm, hv) -> Union[float, bool]:
         # Treat freshly created HVs always passing this check
         if not hv.dataset_obj[self.hv_attribute]:
+            # Because new installed Hypervisors don't have values 
+            # (e.g. for load) - they are fresh meat ...
             return True
 
         # Calculate the remaining "size" of the resource

--- a/igvm/hypervisor_preferences.py
+++ b/igvm/hypervisor_preferences.py
@@ -320,13 +320,13 @@ class PreferenceEvaluator(object):
         # Calculate the overall preference score of the target hv
         self.total = (sum_prefs / (n_prefs - matched_prefs + 1)) / n_prefs
 
-        print('{} on {}: {}/{} prefs, value {}'.format(
-            str(self.vm),
-            str(self.hv),
-            matched_prefs,
-            n_prefs,
-            self.total,
-        ))
+        # print('{} on {}: {}/{} prefs, value {}'.format(
+        #     str(self.vm),
+        #     str(self.hv),
+        #     matched_prefs,
+        #     n_prefs,
+        #     self.total,
+        # ))
 
         return self.total
 
@@ -429,7 +429,8 @@ def sorted_hypervisors(preferences, vm, hypervisors):
         if total > best[0]:
             best = (total, hv)
 
-    print('best hv: {} ({})'.format(str(best[1]), best[0]))
+    # print('best hv: {} ({})'.format(str(best[1]), best[0]))
+    yield best[1]
 
     # for comparables, hypervisor in sorted_hvs:
     #     for executed, comparable in enumerate(comparables):

--- a/igvm/hypervisor_preferences.py
+++ b/igvm/hypervisor_preferences.py
@@ -344,7 +344,7 @@ class PreferenceEvaluator(object):
 
             # Add up the individual preference scores.
             if result > 0.:
-                log.debug('Preference {} matches with score {}.'.format(
+                log.debug('Preference {} matches with score {:.4f}.'.format(
                     str(pref),
                     result,
                 ))
@@ -372,13 +372,13 @@ class PreferenceEvaluator(object):
         # Calculate the overall preference score of the target HV.
         total = (sum_prefs / (n_prefs - matched_prefs + 1)) / n_prefs
 
-        log.debug('Matching {}/{} prefs with a total score of {}.'.format(
+        log.debug('Matching {}/{} prefs with a total score of {:.4f}.'.format(
             matched_prefs,
             n_prefs,
             total,
         ))
 
-        log.info('Hypervisor "{}" selected with a {} score.'.format(
+        log.info('Hypervisor "{}" selected with a {:.4f} score.'.format(
             str(hv),
             total,
         ))

--- a/igvm/hypervisor_preferences.py
+++ b/igvm/hypervisor_preferences.py
@@ -290,6 +290,11 @@ class OverAllocation(HypervisorPreference):
         return '{}({})'.format(type(self).__name__, args)
 
     def get_score(self, vm, hv) -> Union[float, bool]:
+        # New VM has no hypervisor attribute, yet, so we cannot calculate a
+        # score here. We will just allow all HVs to take that VM for now.
+        if not vm.hypervisor:
+            return True
+
         # Calculate the current HVs overbooking "level".
         cur_hv_cpus = sum(
             v[self.attribute] for v in vm.hypervisor.dataset_obj['vms']

--- a/igvm/hypervisor_preferences.py
+++ b/igvm/hypervisor_preferences.py
@@ -7,17 +7,19 @@ A higher score means that a Hypervisor should be favored, while a low one
 discourages a HV. If False or 0.0 is given, that means a HV does not fulfill
 the requirements at all and is excluded.
 
-Copyright (c) 2020 InnoGames GmbH
+Copyright (c) 2021 InnoGames GmbH
 """
+import abc
 from logging import getLogger
 from typing import Union, List
 
 log = getLogger(__name__)
 
 
-class HypervisorPreference:
+class HypervisorPreference(abc.ABC):
     """The base class for all HV preferences."""
 
+    @abc.abstractmethod
     def get_score(self, vm, hv) -> Union[float, bool]:
         """Calculates a preference value to indicate how good a HV fits.
 
@@ -29,7 +31,6 @@ class HypervisorPreference:
                  a very good candidate for this particular preference.
         @rtype: Union[float, bool]
         """
-        raise NotImplementedError('get_preference is not implemented')
 
 
 class InsufficientResource(HypervisorPreference):

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -372,6 +372,4 @@ HYPERVISOR_PREFERENCES = [
     HypervisorAttributeValue('iops_avg'),
     # Prefer the hypervisor with less VMs from the same cluster
     OtherVMs(['project', 'environment', 'game_market']),
-    # As the last resort, choose the hypervisor with less VMs
-    OtherVMs(),
 ]

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -154,6 +154,7 @@ HYPERVISOR_ATTRIBUTES = [
             'num_cpu',
             'project',
             'served_game',
+            'state',
         ],
     },
 ]

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -12,7 +12,6 @@ from libvirt import (
 )
 
 from igvm.hypervisor_preferences import (
-    HashDifference,
     HypervisorAttributeValue,
     HypervisorAttributeValueLimit,
     HypervisorCpuUsageLimit,
@@ -374,6 +373,4 @@ HYPERVISOR_PREFERENCES = [
     OtherVMs(['project', 'environment', 'game_market']),
     # As the last resort, choose the hypervisor with less VMs
     OtherVMs(),
-    # Use hash differences to have a stable ordering
-    HashDifference(),
 ]

--- a/igvm/utils.py
+++ b/igvm/utils.py
@@ -26,36 +26,6 @@ _SIZE_FACTORS = {
 log = logging.getLogger(__name__)
 
 
-class LazyCompare(object):
-    """Lazily execute the given function to compare its result"""
-    def __init__(self, func, *args):
-        self.func = func
-        self.args = args
-        self.executed = False
-        self.result = None
-
-    def __lt__(self, other):
-        return self.sort_key() < other.sort_key()
-
-    def __le__(self, other):
-        return self.sort_key() <= other.sort_key()
-
-    def __eq__(self, other):
-        return self.sort_key() == other.sort_key()
-
-    def __ge__(self, other):
-        return self.sort_key() >= other.sort_key()
-
-    def __gt__(self, other):
-        return self.sort_key() > other.sort_key()
-
-    def sort_key(self):
-        if not self.executed:
-            self.executed = True
-            self.result = self.func(*self.args)
-        return self.result
-
-
 def retry_wait_backoff(fn_check, fail_msg, max_wait=20):
     """Continuously checks a conditional callback and retries with
     exponential backoff intervals until the condition is true.


### PR DESCRIPTION
This is a rework of the hv selection algorithm. It changes the way the preferences work.
Preferences from now on do not return arbitrary numbers or other types but "scores" in the range of 0.0 - 1.0. Booleans are allowed for convenience, but translate to either 0.0 or 1.0, respectively. A score of 0.0 means that the hv will be excluded.
All preferences are evaluated and a total score is calculated, which is also in the range of 0.0 - 1.0.
HVs are then sorted based on the highest score, from high to low. The highest score represents the best fitting hv for a given VM.
This PR also fixes a few issues with the existing preferences.
From my tests I can say that the distribution should definitely improve with this, also it is less likely that similar VMs end up on the same HV.
This is still a work in progress but the general idea and workings of this are done, so I would appreciate some early feedback :)