### PR TITLE
feat(aws): Update cloud_init template for official debian buster AMI

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -299,6 +299,7 @@ def vm_build(vm_hostname, run_puppet=True, debug_puppet=False, postboot=None,
             user_data = template.render(
                 hostname=vm.dataset_obj['hostname'].rstrip('.ig.local'),
                 fqdn=vm.dataset_obj['hostname'],
+                vm_os=vm.dataset_obj['os'],
                 apt_repos=AWS_CONFIG[0]['apt'],
                 puppet_master=vm.dataset_obj['puppet_master'],
                 puppet_ca=vm.dataset_obj['puppet_ca'],

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -260,9 +260,9 @@ AWS_CONFIG = [
                 ],
             },
             {
-                'name': 'basestretch_stable',
-                'filename': 'basestretch_stable.list',
-                'source': 'deb http://update-int.ig.local/ basestretch stable',
+                'name': 'base#VM_OS#_stable',
+                'filename': 'base#VM_OS#_stable.list',
+                'source': 'deb http://update-int.ig.local/ base#VM_OS# stable',
                 'key': [
                     "-----BEGIN PGP PUBLIC KEY BLOCK-----",
                     "Version: GnuPG v1",

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -35,7 +35,7 @@ COMMON_FABRIC_SETTINGS = dict(
 
 # Can't not add a key with dict built above and None value gets interpreted
 # as "None" username, thus separate code.
-if  'IGVM_SSH_USER' in environ:
+if 'IGVM_SSH_USER' in environ:
     COMMON_FABRIC_SETTINGS['user'] = environ.get('IGVM_SSH_USER')
 
 VG_NAME = 'xen-data'

--- a/igvm/templates/aws_user_data.cfg
+++ b/igvm/templates/aws_user_data.cfg
@@ -11,8 +11,8 @@ fqdn: {{ fqdn }}
 apt:
   sources:
 {% for apt_repo in apt_repos -%}
-    {{ apt_repo.filename|indent(4, true) }}:
-      source: "{{ apt_repo.source }}"
+    {{ apt_repo.filename|indent(4, true)|replace("#VM_OS#", vm_os) }}:
+      source: "{{ apt_repo.source|replace("#VM_OS#", vm_os) }}"
       key: |
         {{ apt_repo.key|join("\n")|indent(8, false) }}
 {% endfor %}

--- a/igvm/templates/aws_user_data.cfg
+++ b/igvm/templates/aws_user_data.cfg
@@ -23,6 +23,13 @@ packages:
   - puppet-agent
   - puppet-msgpack
 
+# We need gnupg1 early to add apt GPG Key to apt keyring
+# We need xfsprogs early to format e.g. created logs.img properly before mount
+bootcmd:
+  - [cloud-init-per, once, aptupdate, apt-get, update]
+  - [cloud-init-per, once, gnupg1-aptinstall, apt-get, install, gnupg1, -y]
+  - [cloud-init-per, once, xfsprogs-aptinstall, apt-get, install, xfsprogs, -y]
+
 runcmd:
   - [/opt/puppetlabs/puppet/bin/puppet, agent, --detailed-exitcodes,
     --fqdn={{ fqdn }}, --server={{ puppet_master }},

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -955,6 +955,9 @@ class VM(Host):
         :return: Fitting VM types as list
         """
 
+        if self.dataset_obj['aws_instance_type']:
+            return [self.dataset_obj['aws_instance_type']]
+
         vm_performance_value = self.performance_value()
         region = self.dataset_obj['aws_placement'][:-1]
 

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -455,7 +455,12 @@ class VM(Host):
             result['status'] = 'new'
         return result
 
-    def build(self, run_puppet=True, debug_puppet=False, postboot=None, cleanup_cert=False):
+    def build(
+            self,
+            run_puppet=True,
+            debug_puppet=False,
+            postboot=None,
+            cleanup_cert=False):
         """Builds a VM."""
         hypervisor = self.hypervisor
         self.check_serveradmin_config()
@@ -729,7 +734,6 @@ class VM(Host):
                 raise VMError('Initial puppetrun failed') from e
 
             self.unblock_autostart()
-
 
     def block_autostart(self):
         fd = BytesIO()


### PR DESCRIPTION
This updates our cloud_init template to be able to use the freshly released official debian buster AMI on AWS.
Furthermore it makes it possible to recreate a VM, which didn't have a hypervisor set before but has a specific aws_instance_type assigned.