### PR TITLE
feat(tests): Add AWS as test environment for basic tests

### DIFF
--- a/igvm/exceptions.py
+++ b/igvm/exceptions.py
@@ -56,6 +56,9 @@ class TimeoutError(IGVMError):
     """An operation timed out."""
     pass
 
+class IGVMTestError(IGVMError):
+    """Indicates an error during tests."""
+    pass
 
 class InconsistentAttributeError(IGVMError):
     """An attribute on the VM differs from the excepted value from

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -379,7 +379,14 @@ class VM(Host):
             raise VMError(e)
 
     def is_running(self):
-        return self.hypervisor.vm_running(self)
+        if self.dataset_obj['datacenter_type'] == 'kvm.dct':
+            return self.hypervisor.vm_running(self)
+        elif self.dataset_obj['datacenter_type'] == 'aws.dct':
+            instance_status = self.aws_describe_instance_status(
+                self.dataset_obj['aws_instance_id'])
+            if instance_status == AWS_RETURN_CODES['running']:
+                return True
+            return False
 
     def wait_for_running(self, running=True, timeout=60):
         """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,10 +24,9 @@ if environ.get('PYTEST_XDIST_WORKER_COUNT'):
 else:
     PYTEST_XDIST_WORKER_COUNT = 1
 
-if environ.get('VM_NET'):
-    VM_NET = environ['VM_NET']
-else:
-    VM_NET = 'igvm-net-{}-aw.test.ig.local'.format(JENKINS_EXECUTOR)
+VM_NET = environ.get('VM_NET', default='igvm-net-{}-aw.test.ig.local'.format(
+    JENKINS_EXECUTOR)
+)
 
 VM_HOSTNAME_PATTERN = 'igvm-{}-{}.test.ig.local'
 VM_HOSTNAME = VM_HOSTNAME_PATTERN.format(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,8 +24,10 @@ if environ.get('PYTEST_XDIST_WORKER_COUNT'):
 else:
     PYTEST_XDIST_WORKER_COUNT = 1
 
-
-VM_NET = 'igvm-net-{}-aw.test.ig.local'.format(JENKINS_EXECUTOR)
+if environ.get('VM_NET'):
+    VM_NET = environ['VM_NET']
+else:
+    VM_NET = 'igvm-net-{}-aw.test.ig.local'.format(JENKINS_EXECUTOR)
 
 VM_HOSTNAME_PATTERN = 'igvm-{}-{}.test.ig.local'
 VM_HOSTNAME = VM_HOSTNAME_PATTERN.format(


### PR DESCRIPTION
Adds basic test suite for AWS:
test_vm_build
test_delete
test_rebuild
test_start_stop
test_disk_set
test_sync
which is automatically using AWS environment, if the following env variables are configured:
VM_NET, 
AWS_ACCESS_KEY_ID, 
AWS_SECRET_ACCESS_KEY 
AWS_DEFAULT_REGION