### PR TITLE
Set instance_type after successful build for aws_sync

### DIFF
--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -579,6 +579,7 @@ class VM(Host):
                     MinCount=1,
                     MaxCount=1)
                 log.debug(response)
+                self.dataset_obj['aws_instance_type'] = vm_type
                 break
             except ClientError as e:
                 raise VMError(e)


### PR DESCRIPTION
If we calculate the needed instance_type, we need to
set the used one directly after the build, so we can
query all needed information for this specific type
in aws_sync.