### PR TITLE
[BUGFIX]: Change datatype for getting vm type in aws

### DIFF
--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -1045,7 +1045,7 @@ class VM(Host):
             return [self.dataset_obj['aws_instance_type']]
 
         vm_performance_value = self.performance_value()
-        region = self.dataset_obj['aws_placement'][:-1]
+        region = str(self.dataset_obj['aws_placement'])[:-1]
 
         ecu_target = {
             'min':


### PR DESCRIPTION
This is resolving a bug where we can't set the
aws instance type because of missing region 
information.