### PR TITLE
Fix valuetype bug for memory in aws_sync

### DIFF
--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -922,8 +922,8 @@ class VM(Host):
         price_list = json.loads(response['PriceList'][0])
 
         memory = int(
-            price_list['product']['attributes']['memory'].split()[0]
-        ) * 1024
+            float(price_list['product']['attributes']['memory'].split()[0]
+        ) * 1024)
 
         ec2 = boto3.resource('ec2')
 


### PR DESCRIPTION
This fix is needed because the aws_sync would currently fail if the vm type from AWS
would return "3.75 GB" as memory value.