### PR TITLE
Increase cloud_init provision timeout for AWS

### DIFF
--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -530,7 +530,7 @@ class VM(Host):
                   debug_puppet: bool = False,
                   postboot: Optional[str] = None,
                   timeout_vm_setup: int = 300,
-                  timeout_cloud_init: int = 600) -> None:
+                  timeout_cloud_init: int = 1200) -> None:
         """AWS build
 
         Build a VM in AWS.


### PR DESCRIPTION
The cloud_init duration depends on the current
AWS load and also the used puppet classes. Usually
a provisioning should be done within 600s, but we
already noticed some runs to be longer, e.g. 800s.
So we are on the safe side with 1200s timeout.