### PR TITLE
Fix SSH connect errors during cloud_init provision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ venv/
 .pytest_cache/
 .ropeproject/
 results.xml
+.python-version

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -640,8 +640,8 @@ class VM(Host):
         for retry in range(timeout_cloud_init):
             cloud_init.update(1)
 
-            # Only try to connect every 10s to avoid paramiko exceptions
-            if retry % 10 != 0:
+            # Only try to connect every 20s to avoid paramiko exceptions
+            if retry % 20 != 0:
                 time.sleep(1)
                 continue
 


### PR DESCRIPTION
We need to reduce the amount of our SSH connect tries, otherwise we a SSHException is thrown, which is not catchable.