### PR TITLE
Use Haswell-noTSX to remove missing features

### DIFF
--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -64,7 +64,7 @@ KVM_DEFAULT_MAX_CPUS = 24
 KVM_HWMODEL_TO_CPUMODEL = {
     'Nehalem': ['Dell_R510', 'Dell_M610', 'Dell_M710'],
     'SandyBridge': ['Dell_R320', 'Dell_M620', 'Dell_R620'],
-    'Haswell': ['Dell_R430', 'Dell_M630', 'Dell_M640', 'Dell_R640'],
+    'Haswell-noTSX': ['Dell_R430', 'Dell_M630', 'Dell_M640', 'Dell_R640'],
     'EPYC': ['Dell_R6515'],
 }
 


### PR DESCRIPTION
Intel has disabled TSX on Haswell CPUs due to security vulnerabilities.
hle and rtm are two subfeatures of TSX and because of that, when trying
to spawn VMs on Hypervisors with a newer BIOS version, an error is
thrown because hle and rtm are not available.

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c2955f270a84762343000f103e0640d29c7a96f3