### PR TITLE
Fix VM memory overhead calculation

### DIFF
--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -46,12 +46,12 @@ RESERVED_DISK = {
 }
 
 # Reserved memory for host OS in MiB
-HOST_RESERVED_MEMORY = {
+HOST_RESERVED_MEMORY_MIB = {
     'logical': 2 * 1024,
     'zfs': 8 * 1024,
 }
 
-VM_OVERHEAD_MEMORY = 50
+VM_OVERHEAD_MEMORY_MIB = 50
 
 
 # Default max number of CPUs, unless the hypervisor has fewer cores or num_cpu


### PR DESCRIPTION
Previously, the VM memory overhead was only applied once for the
whole Hypervisor. Which is wrong, because every VM has its very own
memory overhead in QEMU.
This commit fixes this calculation and therefore prevents unintended
overallocation and/or swapping of VM memory on the Hypervisor.