### PR TITLE
Add a flag to overrule Hypervisor preferences

### DIFF
--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -125,6 +125,16 @@ def parse_args():
         action='store_true',
         help='Rebuild already defined VM or build it if not defined',
     )
+    subparser.add_argument(
+        '--soft-preferences',
+        dest='soft_preferences',
+        action='store_true',
+        help='Overrules all preferences so that Hypervisors are not excluded. '
+             'Use this if igvm fails to find a matching Hypervisor, but you '
+             'are in urgent need to do it anyway. Hint: If igvm fails to find '
+             'a matching Hypervisor something might be really wrong. Run igvm '
+             'with --verbose to check why it fails finding a Hypervisor.',
+    )
 
     subparser = subparsers.add_parser(
         'migrate',
@@ -191,6 +201,16 @@ def parse_args():
         type=int,
         help='Resize disk of migrated VM. '
         'Works only with --offline --offline-transport=xfs',
+    )
+    subparser.add_argument(
+        '--soft-preferences',
+        dest='soft_preferences',
+        action='store_true',
+        help='Overrules all preferences so that Hypervisors are not excluded. '
+             'Use this if igvm fails to find a matching Hypervisor, but you '
+             'are in urgent need to do it anyway. Hint: If igvm fails to find '
+             'a matching Hypervisor something might be really wrong. Run igvm '
+             'with --verbose to check why it fails finding a Hypervisor.',
     )
 
     subparser = subparsers.add_parser(
@@ -431,6 +451,16 @@ def parse_args():
         dest='allow_reserved_hv',
         action='store_true',
         help='Allow migrating to a host which has the state online_reserved',
+    )
+    subparser.add_argument(
+        '--soft-preferences',
+        dest='soft_preferences',
+        action='store_true',
+        help='Overrules all preferences so that Hypervisors are not excluded. '
+             'Use this if igvm fails to find a matching Hypervisor, but you '
+             'are in urgent need to do it anyway. Hint: If igvm fails to find '
+             'a matching Hypervisor something might be really wrong. Run igvm '
+             'with --verbose to check why it fails finding a Hypervisor.',
     )
 
     subparser = subparsers.add_parser(


### PR DESCRIPTION
This adds a flag "--soft-preferences" to the build, migrate and
evacuate commands of igvm. Setting them causes the Hypervisor
selection algorithm to behave slightly different. Instead of
excluding Hypervisors if any of the preferences fails it will instead
keep them with an accordingly lower ranked overall score. This way we
can force all Hypervisors to be considered as targets while still
leaving the hard checks for later on to check if VMs really fit.
In emergency cases this can help emptying Hypervisors or just moving
a specific VM to the "less worst" available location. It can also be
used to force a VM build and squeeze it in somewhere.