### PR TITLE
Remove cpu_util_vm_pct preference from old times

### DIFF
--- a/igvm/hypervisor_preferences.py
+++ b/igvm/hypervisor_preferences.py
@@ -227,7 +227,7 @@ class HypervisorCpuUsageLimit(HypervisorPreference):
 
         # Bail out if hardware_model is not in HYPERVISOR_CPU_THRESHOLDS list.
         if hv_model not in self.hv_cpu_thresholds:
-            log.warning(
+            log.error(
                 'Missing setting for "{}" in HYPERVISOR_CPU_THRESHOLDS'.format(
                     hv_model,
                 ),

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -117,7 +117,6 @@ IMAGE_PATH = '/tmp'
 HYPERVISOR_ATTRIBUTES = [
     'cpu_perffactor',
     'cpu_util_pct',
-    'cpu_util_vm_pct',
     'environment',
     'hardware_model',
     'hostname',
@@ -337,10 +336,6 @@ HYPERVISOR_PREFERENCES = [
     # Compares the environment of the VM with the environment of the
     # hypervisor. It makes hypervisors of different envs less likely chosen.
     HypervisorEnvironmentValue('environment'),
-    # Checks the maximum vCPU usage (95 percentile) of the given hypervisor
-    # for the given time_range and dismisses it as target when it is over
-    # the value of threshold.
-    HypervisorAttributeValueLimit('cpu_util_vm_pct', 45),
     # Calculates the performance_value of the given VM, which is comparable
     # across hypervisor hardware models. It uses this value to predict the
     # CPU usage of the VM on the destination hypervisor and dismisses all


### PR DESCRIPTION
We used to express the CPU usage limit of HVs with the
cpu_util_vm_pct metric. For quite some time now, though, we came up
with a better way by setting specific thresholds for specific
hardware models that are backed by load tests. There is no reason to
keep the old limiting preference anymore. We can safely drop it.