### PR TITLE
Sort out AWS instance_types with no ipv6 support

### DIFF
--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -1095,6 +1095,8 @@ class VM(Host):
         for t in overview:
             if region not in t['pricing']:
                 continue
+            if not t['ipv6_support']:
+                continue
             if t['memory'] < (self.dataset_obj['memory'] / 1024):
                 continue
             if 'ECU' not in t or not isinstance(t['ECU'], (int, float)):


### PR DESCRIPTION
When we are crawling the AWS instances overview
file, we need to sort out potential instance_types
which do not have any ipv6 support, as it will break
the VM build with a sleep loop.