### PR TITLE
Strip hostname out of FQDN for AWS user_data

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -327,7 +327,7 @@ def vm_build(
             jenv = Environment(loader=PackageLoader('igvm', 'templates'))
             template = jenv.get_template('aws_user_data.cfg')
             user_data = template.render(
-                hostname=vm.dataset_obj['hostname'].rstrip('.ig.local'),
+                hostname=vm.dataset_obj['hostname'].replace('.ig.local', ''),
                 fqdn=vm.dataset_obj['hostname'],
                 vm_os=vm.dataset_obj['os'],
                 apt_repos=AWS_CONFIG[0]['apt'],


### PR DESCRIPTION
We need the FQDN and the hostname for initial cloud_init
setup, to put these into /etc/hosts after first boot.
The previous rstrip broke the hostname for specific projects.