### PR TITLE
Switch to gnupg(2) package in AWS

### DIFF
--- a/igvm/templates/aws_user_data.cfg
+++ b/igvm/templates/aws_user_data.cfg
@@ -23,11 +23,11 @@ packages:
   - puppet-agent
   - puppet-msgpack
 
-# We need gnupg1 early to add apt GPG Key to apt keyring
+# We need gnupg early to add apt GPG Key to apt keyring
 # We need xfsprogs early to format e.g. created logs.img properly before mount
 bootcmd:
   - [cloud-init-per, once, aptupdate, apt-get, update]
-  - [cloud-init-per, once, gnupg1-aptinstall, apt-get, install, gnupg1, -y]
+  - [cloud-init-per, once, gnupg-aptinstall, apt-get, install, gnupg, -y]
   - [cloud-init-per, once, xfsprogs-aptinstall, apt-get, install, xfsprogs, -y]
 
 runcmd:


### PR DESCRIPTION
The old gnupg1 package only provides gpg1 (obviously) and no /usr/bin/gpg
binary, which Puppet requires to import apt keys.
This commit upgrades to gpg2 and fixes Puppet provider issues.