### PR TITLE
Use FQDN as hostname for /etc/hostname

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -327,7 +327,7 @@ def vm_build(
             jenv = Environment(loader=PackageLoader('igvm', 'templates'))
             template = jenv.get_template('aws_user_data.cfg')
             user_data = template.render(
-                hostname=vm.dataset_obj['hostname'].replace('.ig.local', ''),
+                hostname=vm.dataset_obj['hostname'],
                 fqdn=vm.dataset_obj['hostname'],
                 vm_os=vm.dataset_obj['os'],
                 apt_repos=AWS_CONFIG[0]['apt'],


### PR DESCRIPTION
According to the man page (man hostname) one should either use a
hostname (no dots) or the FQDN as nowadays most software is able to cope
with a full FQDN.

Using an incomplete FQDN (e.g. ursula.example) is a bad idea because software
such as Puppet facter checks for dots in the hostname and extracts hostname
and FQDN information based on the presence of dots in the hostname.

Given the two options:

1. Hostname (no dots)
2. FQDN (ursula.example.com but not ursula.example)

We go for the FQDN as the hostname can be ambigious in our
infrastructure.

Downside is the /etc/hosts does not include our alias ursula.example
during the cloud-init process but this is fixed with the first run of
puppet that manages the /etc/hosts.