### PR TITLE
Remove AWS_PROFILE_NAME environment variable

### DIFF
--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -207,7 +207,6 @@ AWS_INSTANCES_OVERVIEW_URL = 'https://www.ec2instances.info/instances.json'
 AWS_INSTANCES_OVERVIEW_FILE = '/tmp/AWS_INSTANCES_OVERVIEW_FILE.json'
 AWS_INSTANCES_OVERVIEW_FILE_ETAG = '/tmp/AWS_INSTANCES_OVERVIEW_FILE.etag'
 AWS_ECU_FACTOR = 7
-AWS_PROFILE_NAME = environ.get('AWS_PROFILE_NAME', default='default')
 
 AWS_CONFIG = [{
     'apt': [{

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -37,7 +37,6 @@ from igvm.settings import (
     AWS_INSTANCES_OVERVIEW_FILE_ETAG,
     AWS_INSTANCES_OVERVIEW_URL,
     AWS_GRP_NAME,
-    AWS_PROFILE_NAME,
 )
 from igvm.transaction import Transaction
 from igvm.utils import parse_size, wait_until
@@ -237,11 +236,9 @@ class VM(Host):
     @property
     def aws_session(self) -> boto3.Session:
         if not self.__aws_session:
-            region = str(self.dataset_obj['aws_placement'])[:-1]
             self.__aws_session = boto3.Session(
-                profile_name=AWS_PROFILE_NAME,
-                region_name=region,
-            )
+                region_name=str(self.dataset_obj['aws_placement'])[:-1])
+
         return self.__aws_session
 
     @property


### PR DESCRIPTION
Do not implicitely enforce usage of an AWS credentials file but allow
using only environment variables. This is at least useful for CI/CD test
environments.

One can still configure the profile using the official AWS_PROFILE
environment variable.