### PR TITLE
Mitigate network and puppetrun issues

### DIFF
--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -27,7 +27,7 @@ COMMON_FABRIC_SETTINGS = dict(
     forward_agent=True,
     shell='/bin/sh -c',
     timeout=5,
-    connection_attempts=1,
+    connection_attempts=3,
     remote_interrupt=True,
 )
 

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -858,7 +858,7 @@ class VM(Host):
                     key_id, fp_id, fp_type(pub_key).hexdigest()
                 ))
 
-    def run_puppet(self, clear_cert=False, debug=False):
+    def run_puppet(self, clear_cert=False, debug=False, tries=2):
         """Runs Puppet in chroot on the hypervisor."""
 
         if clear_cert:
@@ -881,10 +881,20 @@ class VM(Host):
                 )
             )
 
-            try:
-                self.run(puppet_command)
-            except RemoteCommandError as e:
-                raise VMError('Initial puppetrun failed') from e
+            # The Puppetserver fails sometimes with HTTP 500 or isn't reachable
+            while tries > 0:
+                tries -= 1
+                try:
+                    self.run(puppet_command)
+                except RemoteCommandError as e:
+                    if tries == 0:
+                        raise VMError('Initial puppetrun failed') from e
+
+                    logging.warning(
+                        f'Initial puppetrun failed {tries} retries left.')
+                else:
+                    # puppetrun was successful
+                    break
 
             self.unblock_autostart()
 


### PR DESCRIPTION
Tests seem to randomly fail because of time outs. I am unsure if this is
due to network interruptions or timing issues in the order of executing
commands.

Maybe this helps.