### PR TITLE
Allow specifying the target HV as a query

### DIFF
--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -98,6 +98,12 @@ def parse_args():
         help='Hostname of the guest system',
     )
     subparser.add_argument(
+        'target_hv_query',
+        nargs='?',
+        default=None,
+        help='Hostname or query of destination hypervisor/s (to pick from)',
+    )
+    subparser.add_argument(
         '--postboot',
         metavar='postboot_script',
         help='Run postboot_script on the guest after first boot',
@@ -155,10 +161,10 @@ def parse_args():
         help='Hostname of the guest system',
     )
     subparser.add_argument(
-        'hypervisor_hostname',
+        'target_hv_query',
         nargs='?',
         default=None,
-        help='Hostname of destination hypervisor',
+        help='Hostname or query of destination hypervisor/s (to pick from)',
     )
     subparser.add_argument(
         '--run-puppet',
@@ -440,10 +446,10 @@ def parse_args():
         help='Hostname of the hypervisor',
     )
     subparser.add_argument(
-        'dst_hv_hostname',
+        'target_hv_query',
         nargs='?',
         default=None,
-        help='Hostname of destination hypervisor',
+        help='Hostname or query of destination hypervisor/s (to pick from)',
     )
     subparser.add_argument(
         '--dry-run',


### PR DESCRIPTION
Previously it was only possible to specify specific single target HV
hostnames. This change allows specifying a Serveradmin query instead
to select a range of possible HVs to pick from. The "best" HV among
those will automatically be chosen by igvm.
This affects the "migrate" and "evacuate" commands and also adds this
parameter to the "build" command.
The changes are fully backwards-compatible and can be used just like
before, resulting in the same behavior.