### PR TITLE
Fix xfs offline transfer for bullseye

### DIFF
--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -970,8 +970,8 @@ class Hypervisor(Host):
         #  -J: inhibits inventory update
         # xfsrestore needs to output its logs, otherwise it fails
         self.run(
-            'nohup /bin/nc.openbsd -l -p {0} '
-            '| ionice -c3 xfsrestore -F -J - {1} 2>{2} 1>&2 &'
+            'nohup /bin/nc.openbsd -l -p {0} 2>>{2} '
+            '| ionice -c3 xfsrestore -F -J - {1} 2>>{2} 1>&2 &'
             .format(port, mount_dir, self._xfsrestore_log_name(vm)),
             pty=False,  # Has to be here for background processes
         )


### PR DESCRIPTION
Some software in bullseye got a bit more picky with handling default
file handles, like stderr. I suppose the behavior is actually correct
now on bullseye.
Previously the command would return just fine and detach to the
background and the ssh channel would close. However, we never
redirected stderr of the nc.openbsd command, so it was still attached
to the ssh channel. On bullseye this will now keep the channel open.
This leads to the command never returning and blocking the execution
flow forever, resulting in a stuck migration.
The fix is to add a stderr redirection to the nc.openbsd command.