### PR TITLE
Use limit function for possible faulty values on HVs

### DIFF
--- a/igvm/hypervisor_preferences.py
+++ b/igvm/hypervisor_preferences.py
@@ -193,6 +193,14 @@ class HypervisorAttributeValueLimit(HypervisorPreference):
 
         # When the actual value is above the limit, we strike out that HV.
         if value > self.limit:
+            log.warning(
+                'Hypervisor "{}" skipped because {} attribute is higher '
+                'than expected ({} > {}).'.format(
+                    str(hv),
+                    self.limit,
+                    value
+                ),
+            )
             return False
 
         # Normalize the value. This is only valid for percentage values like

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -13,7 +13,7 @@ from libvirt import (
 )
 
 from igvm.hypervisor_preferences import (
-    HypervisorAttributeValue,
+    HypervisorAttributeValueLimit,
     HypervisorCpuUsageLimit,
     HypervisorEnvironmentValue,
     InsufficientResource,
@@ -408,9 +408,9 @@ HYPERVISOR_PREFERENCES = [
     # Less over-allocated (CPU) hypervisors first
     OverAllocation('num_cpu'),
     # Find less loaded Hypervisor
-    HypervisorAttributeValue('cpu_util_pct'),
+    HypervisorAttributeValueLimit('cpu_util_pct', 100),
     # Find Hypervisor with less I/O utilization
-    HypervisorAttributeValue('iops_avg'),
+    HypervisorAttributeValueLimit('iops_avg', 100),
     # Prefer the hypervisor with less VMs from the same cluster
     OtherVMs(['project', 'environment', 'game_market']),
 ]


### PR DESCRIPTION
It would make to skip a hypervisor with a faulty value instead of crashing the whole selection process because of it. Normalization on the next step on `HypervisorAttributeValue` and `HypervisorAttributeValueLimit` functions currently naively assume that the values are below 100.
Relates to: GOP-27242