### PR TITLE
Exclude instance types, which don't have pricing information

### DIFF
--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -1174,9 +1174,10 @@ class VM(Host):
         }
 
         vm_types = dict()
-
         for t in overview:
             if region not in t['pricing']:
+                continue
+            if 'linux' not in t['pricing'][region]:
                 continue
             if not t['ipv6_support']:
                 continue


### PR DESCRIPTION
Our selection of the appropriate instance type is based on sorting by price. If no price information is available for the instance type in the selected region, we cannot consider it.