### PR TITLE
Improve message waiting for memory to become visible

### DIFF
--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -333,9 +333,7 @@ class Hypervisor(Host):
             # wait until MemTotal changes.
             retry_wait_backoff(
                 lambda: vm.meminfo()['MemTotal'] != old_total,
-                'New memory is not visible to virtual machine. Note that we '
-                'can not online decrease the domains memory. The libvirt '
-                'and serveradmin changes will therefore not be rolled back.',
+                'New memory is not yet visible to virtual machine.',
                 max_wait=40
             )
 


### PR DESCRIPTION
We exit when trying to shrink memory on a online VM a few lines before and we tell the user that we cannot rollback the memory if it failed a few lines afterwards in the sanity check so there is no point of spaming the user here (anymore).