### PR TITLE
Ensure selection of fallback instance type if necessary

### DIFF
--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -659,9 +659,9 @@ class VM(Host):
         """
 
         vm_types_overview = self.aws_get_instances_overview()
-        if vm_types_overview:
-            vm_types = self.aws_get_fitting_vm_types(vm_types_overview)
-        else:
+        vm_types = self.aws_get_fitting_vm_types(vm_types_overview)
+
+        if not vm_types:
             vm_types = [AWS_FALLBACK_INSTANCE_TYPE]
 
         root_device = list(


### PR DESCRIPTION
It may happen that we cannot find an instance type for a VM because the load values are too low. In this case, the build would simply stop. This change ensures that we always have at least the fallback instance type when installing.