### PR TITLE
Adjust hypervisor state check logic

### DIFF
--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -57,7 +57,7 @@ class Hypervisor(Host):
     def __init__(self, dataset_obj):
         super(Hypervisor, self).__init__(dataset_obj)
 
-        if dataset_obj['state'] == 'retired':
+        if dataset_obj['state'] not in ['online', 'online_reserved']:
             raise InvalidStateError(
                 'Hypervisor "{0}" is retired.'.format(self.fqdn)
             )


### PR DESCRIPTION
As we now have the cold_standby state, it doesn't make sense to check for retired only.

This was an issue for hypervisors in maintenance state as well, as igvm should never operate on them.