### PR TITLE
Disable shell and PTY in Puppet commands

### DIFF
--- a/igvm/puppet.py
+++ b/igvm/puppet.py
@@ -100,7 +100,7 @@ def run_cmd(host: str, cmd: str) -> Result:
         user = None
 
     with settings(host_string=host, user=user, warn_only=True):
-        return sudo(cmd, quiet=True)
+        return sudo(cmd, quiet=True, pty=False, shell=False)
 
 
 def find_puppet_executable(host: str) -> str:


### PR DESCRIPTION
Forgot this part. Required for some automation scripts/tools