### PR TITLE
Cleanup hypervisor attribute when retiring a VM

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -694,6 +694,9 @@ def vm_delete(vm_hostname, retire=False):
         # or update its state to 'retired' if retire is True.
         if retire:
             vm.dataset_obj['state'] = 'retired'
+            # We must clean the hypervisor attribute, as we enforce that no
+            # hypervisor has retired VMs assigned to it.
+            vm.dataset_obj['hypervisor'] = None
             vm.dataset_obj.commit()
             log.info(
                 '"{}" is destroyed and set to "retired" state.'.format(


### PR DESCRIPTION
We extended the libvirt_hosts check to enfore retired VMs are not assigned to a hypervisor, so we most ensure the attribute gets cleaned when a VM gets retired by igvm.