### PR TITLE
Pin markupsafe dependency to 1.1

### DIFF
--- a/igvm/__init__.py
+++ b/igvm/__init__.py
@@ -1,6 +1,6 @@
 """igvm - Main Module
 
-Copyright (c) 2022 InnoGames GmbH
+Copyright (c) 2024 InnoGames GmbH
 """
 
-VERSION = (2, 2, 1)
+VERSION = (2, 2, 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ paramiko~=2.7
 Fabric3~=1.14
 libvirt-python>=7,<=9
 jinja2~=2.11
+markupsafe~=1.1
 boto3~=1.26
 tqdm~=4.57


### PR DESCRIPTION
Markupsafe 1.1.1 is the latest version shipped with Debian Bullseye which we are currently using.

Not specifying a version makes us run into a bug where markupsafe removed a dependency in a minor version (semver violation) when using jinja2 in version 2.x.

See: https://github.com/pallets/markupsafe/issues/304

This can be removed once we are on Debian Bookworm using Jinja 3.x