### PR TITLE
Add missing dependency setuptools

### DIFF
--- a/igvm/__init__.py
+++ b/igvm/__init__.py
@@ -3,4 +3,4 @@
 Copyright (c) 2024 InnoGames GmbH
 """
 
-VERSION = (2, 2, 2)
+VERSION = (2, 2, 3)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools~=73.0
 adminapi@git+https://github.com/innogames/serveradmin.git@v4.15.0#egg=adminapi
 netaddr~=0.8
 cffi~=1.14


### PR DESCRIPTION
Apparently many libraries rely on setuptools to be present without specifying it as dependency and so does jinja2

See: https://github.com/pallets/jinja/issues/1192