### PR TITLE
Support different VG names

### DIFF
--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -10,7 +10,6 @@ import time
 
 from fabric.network import disconnect_all
 
-from igvm.settings import DEFAULT_VG_NAME
 from igvm.commands import (
     change_address,
     clean_cert,
@@ -110,14 +109,6 @@ def parse_args():
         '--postboot',
         metavar='postboot_script',
         help='Run postboot_script on the guest after first boot',
-    )
-    subparser.add_argument(
-        '--vg-name',
-        metavar='vg_name',
-        default=DEFAULT_VG_NAME,
-        help='Name of the volume group to use for the VM (default: {})'.format(
-            DEFAULT_VG_NAME
-        ),
     )
     subparser.add_argument(
         '--skip-puppet',

--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -10,6 +10,7 @@ import time
 
 from fabric.network import disconnect_all
 
+from igvm.settings import DEFAULT_VG_NAME
 from igvm.commands import (
     change_address,
     clean_cert,
@@ -109,6 +110,14 @@ def parse_args():
         '--postboot',
         metavar='postboot_script',
         help='Run postboot_script on the guest after first boot',
+    )
+    subparser.add_argument(
+        '--vg-name',
+        metavar='vg_name',
+        default=DEFAULT_VG_NAME,
+        help='Name of the volume group to use for the VM (default: {})'.format(
+            DEFAULT_VG_NAME
+        ),
     )
     subparser.add_argument(
         '--skip-puppet',

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -987,6 +987,14 @@ def _get_vm(hostname, unlock=True, allow_retired=False, vg_name=None):
                     hostname,
                 )
             )
+        if (
+            dataset_obj['libvirt_pool_override'] is not None
+            and dataset_obj['hypervisor'] is None
+        ):
+            raise InvalidStateError(
+                'Automatic HV selection is not possible for VMs with special '
+                'VG name requirements. Please specify a HV manually.'
+            )
         yield vm
     except (Exception, KeyboardInterrupt):
         VM(vm_query(), hypervisor).release_lock()

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -320,7 +320,6 @@ def vm_build(
     soft_preferences: bool = False,
     barebones: bool = False,
     target_hv_query: Optional[str] = None,
-    vg_name: str = '',
 ):
     """Create a VM and start it
 
@@ -330,7 +329,6 @@ def vm_build(
     with ExitStack() as es:
         vm = es.enter_context(_get_vm(
             hostname=vm_hostname,
-            vg_name=vg_name  # Need to pass only while building
         ))
 
         if vm.dataset_obj['datacenter_type'] == 'aws.dct':
@@ -979,7 +977,7 @@ def _get_vm(hostname, unlock=True, allow_retired=False, vg_name=None):
             dataset_obj, 'hypervisor', dataset_obj['hypervisor']['hostname']
         )
 
-    vm = VM(dataset_obj=dataset_obj, hypervisor=hypervisor, vg_name=vg_name)
+    vm = VM(dataset_obj=dataset_obj, hypervisor=hypervisor)
     vm.acquire_lock()
 
     try:

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -404,7 +404,6 @@ def vm_build(
                 postboot=postboot,
                 cleanup_cert=rebuild,
                 barebones=barebones,
-                vg_name=vm.vg_name,
             )
         else:
             raise NotImplementedError(

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -509,8 +509,13 @@ def vm_migrate(
 
         with Transaction() as transaction:
             _vm.hypervisor.migrate_vm(
-                _vm, hypervisor, offline, offline_transport, transaction,
-                no_shutdown, disk_size,
+                vm=_vm,
+                target_hypervisor=hypervisor,
+                offline=offline,
+                offline_transport=offline_transport,
+                transaction=transaction,
+                no_shutdown=no_shutdown,
+                disk_size=disk_size,
             )
             previous_hypervisor = _vm.hypervisor
             _vm.hypervisor = hypervisor
@@ -521,7 +526,10 @@ def vm_migrate(
             transaction.on_rollback('reset hypervisor', _reset_hypervisor)
 
             if run_puppet:
-                hypervisor.mount_vm_storage(_vm, transaction)
+                hypervisor.mount_vm_storage(
+                    vm=_vm,
+                    transaction=transaction,
+                )
                 _vm.run_puppet(debug=debug_puppet)
                 hypervisor.umount_vm_storage(_vm)
 

--- a/igvm/drbd.py
+++ b/igvm/drbd.py
@@ -6,6 +6,7 @@ Copyright (c) 2018 InnoGames GmbH
 from adminapi import api
 from contextlib import contextmanager
 from igvm.exceptions import RemoteCommandError
+from igvm.settings import DEFAULT_VG_NAME
 from io import BytesIO
 from logging import getLogger
 from time import sleep
@@ -20,6 +21,11 @@ class DRBD(object):
         self.hv = hv
         self.master_role = master_role
 
+        if vm.vg_name != DEFAULT_VG_NAME:
+            raise NotImplementedError(
+                'DRBD migration only supported for volumes in the {} VG'
+                .format(DEFAULT_VG_NAME)
+            )
         lv = vm.hypervisor.get_volume_by_vm(vm).path()
         lv_name = lv.split('/')
         self.vg_name = lv_name[2]

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -729,7 +729,7 @@ class Hypervisor(Host):
             elif offline_transport == 'xfs':
                 self._wait_for_shutdown(vm, no_shutdown, transaction)
                 with target_hypervisor.xfsrestore(
-                    vm=vm, transaction=transaction, vg_name=target_vg_name
+                    vm=vm, transaction=transaction
                 ) as listener:
                     self.xfsdump(vm, listener, transaction)
 

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -66,7 +66,7 @@ class Hypervisor(Host):
         self._storage_type = None
 
     def get_active_storage_pools(self):
-        # Return all active storage pools
+        # The 2 used as argument is the value of the VIR_CONNECT_LIST_STORAGE_POOLS_ACTIVE flag.
         return self.conn().listAllStoragePools(2)
 
     def find_vg_of_vm(self, dataset_obj):
@@ -738,7 +738,7 @@ class Hypervisor(Host):
                 target_hypervisor.umount_vm_storage(vm)
 
             target_hypervisor.define_vm(
-                vm=vm, transaction=transaction, vg_name=target_vg_name
+                vm=vm, transaction=transaction
             )
         else:
             # For online migrations always use same volume name as VM
@@ -828,7 +828,7 @@ class Hypervisor(Host):
         # XXX: undefine_vm depends on vm.fqdn beeing the old name for finding
         # legacy domains w/o an uid_name.  The order is therefore important.
         vm.fqdn = new_fqdn or vm.fqdn
-        self.define_vm(vm=vm, vg_name=vm.vg_name)
+        self.define_vm(vm=vm)
 
     def _vm_sync_from_hypervisor(self, vm, result):
         vm_info = self._get_domain(vm).info()

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -225,7 +225,7 @@ class Hypervisor(Host):
             )
 
         # Enough disk?
-        free_disk_space = self.get_free_disk_size_gib()
+        free_disk_space = self.get_free_disk_size_gib(vg_name=vm.vg_name)
         vm_disk_size = float(vm.dataset_obj['disk_size_gib'])
         if vm_disk_size > free_disk_space:
             raise HypervisorError(

--- a/igvm/kvm.py
+++ b/igvm/kvm.py
@@ -31,7 +31,6 @@ from igvm.settings import (
     KVM_DEFAULT_MAX_CPUS,
     KVM_HWMODEL_TO_CPUMODEL,
     MAC_ADDRESS_PREFIX,
-    VG_NAME,
     MIGRATE_CONFIG,
 )
 from igvm.utils import parse_size, parallel
@@ -369,7 +368,7 @@ def generate_domain_xml(hypervisor, vm):
 
     config = {
         'name': vm.uid_name,
-        'disk_pool': VG_NAME,
+        'disk_pool': vm.vg_name,
         'disk_volume': hypervisor.get_volume_by_vm(vm).name(),
         'io_weight': (
             500 if vm.dataset_obj['io_weight'] == 'default' else 250

--- a/igvm/puppet.py
+++ b/igvm/puppet.py
@@ -9,7 +9,6 @@ from time import sleep
 from adminapi.dataset import Query, DatasetObject
 from fabric.api import settings
 from fabric.operations import sudo
-from fabric2 import Result
 
 from igvm.exceptions import ConfigError
 from igvm.settings import COMMON_FABRIC_SETTINGS
@@ -93,7 +92,7 @@ def clean_cert(vm: DatasetObject, retries: int = 10) -> None:
     )
 
 
-def run_cmd(host: str, cmd: str) -> Result:
+def run_cmd(host: str, cmd: str):
     if 'user' in COMMON_FABRIC_SETTINGS:
         user = COMMON_FABRIC_SETTINGS['user']
     else:

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -188,6 +188,7 @@ VM_ATTRIBUTES = [
     'igvm_locked',
     'intern_ip',
     'io_weight',
+    'libvirt_pool_override',
     'load_99',
     'mac',
     'memory',

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -37,7 +37,7 @@ COMMON_FABRIC_SETTINGS = dict(
 if 'IGVM_SSH_USER' in environ:
     COMMON_FABRIC_SETTINGS['user'] = environ.get('IGVM_SSH_USER')
 
-VG_NAME = 'xen-data'
+DEFAULT_VG_NAME = 'xen-data'
 # Reserved pool space on Hypervisor
 # TODO: this could be a percent value, at least for ZFS.
 RESERVED_DISK = {

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -69,8 +69,9 @@ class VM(Host):
     __ec2r = None
     __vpc = None
     __consolidated_sg = None
+    vg_name = None
 
-    def __init__(self, dataset_obj, hypervisor=None, vg_name=None):
+    def __init__(self, dataset_obj, hypervisor=None):
         super(VM, self).__init__(dataset_obj)
         self.hypervisor = hypervisor
 
@@ -80,21 +81,10 @@ class VM(Host):
         # directly on running VM.
         self.mounted = False
 
-        if vg_name is None:
-            # Check if we can find it
-
-            if hypervisor is None:
-                # At AWS we don't have assigned hypervisors hence no vg_name.
-                self.vg_name = None
-            else:
-                found_vg = self.hypervisor.find_vg_of_vm(dataset_obj)
-                if found_vg:
-                    self.vg_name = found_vg
-                else:
-                    # Should not happen, but we assume it is the default
-                    self.vg_name = DEFAULT_VG_NAME
+        if dataset_obj['libvirt_pool_override']:
+            self.vg_name = dataset_obj['libvirt_pool_override']
         else:
-            self.vg_name = vg_name
+            self.vg_name = DEFAULT_VG_NAME
 
     def vm_host(self):
         """ Return correct ssh host for mounted and unmounted vm """

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -84,8 +84,7 @@ class VM(Host):
 
         if self.mounted:
             return self.hypervisor.fabric_settings()
-        else:
-            return self.fabric_settings()
+        return self.fabric_settings()
 
     def vm_path(self, path=''):
         """ Append correct prefix to reach VM's / directory """
@@ -95,8 +94,7 @@ class VM(Host):
                 self.hypervisor.vm_mount_path(self),
                 path,
             )
-        else:
-            return '/{}'.format(path)
+        return '/{}'.format(path)
 
     def run(self, command, silent=False, with_sudo=True):
         """ Same as Fabric's run() but works on mounted or running vm
@@ -115,8 +113,7 @@ class VM(Host):
                     silent=silent,
                     with_sudo=with_sudo,
                 )
-            else:
-                return super(VM, self).run(command, silent=silent)
+            return super(VM, self).run(command, silent=silent)
 
     def read_file(self, path):
         """Read a file from a running VM or a mounted image on HV."""
@@ -667,20 +664,22 @@ class VM(Host):
             transaction.on_rollback('Clean cert', clean_cert, self.dataset_obj)
 
             # Perform operations on the hypervisor
-            self.hypervisor.create_vm_storage(self, transaction)
+            self.hypervisor.create_vm_storage(
+                vm=self, transaction=transaction
+            )
 
             # The following operations are only performed in case we
             # don't want to build a barebones VM
             if not barebones:
                 mount_path = self.hypervisor.format_vm_storage(
-                    self, transaction
+                    vm=self, transaction=transaction
                 )
                 self.hypervisor.download_and_extract_image(image, mount_path)
 
             # This needs to happen at this point, so that the memory
             # usage of this VM is already taken into consideration if
             # a hypervisor is selected during a later igvm build run.
-            hypervisor.define_vm(self, transaction)
+            hypervisor.define_vm(vm=self, transaction=transaction)
 
             # Unlocking here is safe, because we keep the state in the
             # hypervisor object and a second release will trigger no

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -84,8 +84,7 @@ class VM(Host):
             # Check if we can find it
 
             if hypervisor is None:
-                # This is probably caused by an error,
-                # but we will pass as None
+                # At AWS we don't have assigned hypervisors hence no vg_name.
                 self.vg_name = None
             else:
                 found_vg = self.hypervisor.find_vg_of_vm(dataset_obj)
@@ -661,7 +660,6 @@ class VM(Host):
             postboot=None,
             cleanup_cert=False,
             barebones=False,
-            vg_name=DEFAULT_VG_NAME,
     ):
         """Builds a VM."""
         hypervisor = self.hypervisor

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -49,7 +49,7 @@ from igvm.settings import (
     HYPERVISOR_ATTRIBUTES,
     HYPERVISOR_CPU_THRESHOLDS,
     KVM_HWMODEL_TO_CPUMODEL,
-    VG_NAME,
+    DEFAULT_VG_NAME,
     VM_ATTRIBUTES
 )
 from igvm.utils import parse_size
@@ -156,7 +156,7 @@ class IGVMTest(TestCase):
         clean_cert(self.vm_obj)
         clean_all(self.route_network, self.datacenter_type, VM_HOSTNAME)
 
-    def check_vm_present(self, vm_name=VM_HOSTNAME):
+    def check_vm_present(self, vm_name=VM_HOSTNAME, vg_name=DEFAULT_VG_NAME):
         # Operate on fresh object
         with _get_vm(vm_name) as vm:
             for hv in self.hvs:
@@ -168,7 +168,7 @@ class IGVMTest(TestCase):
                     # Is it gone from other HVs after migration?
                     self.assertEqual(hv.vm_defined(vm), False)
                     hv.run(
-                        'test ! -b /dev/{}/{}'.format(VG_NAME, self.uid_name)
+                        'test ! -b /dev/{}/{}'.format(vg_name, self.uid_name)
                     )
 
             # Is VM itself alive and fine?
@@ -176,7 +176,7 @@ class IGVMTest(TestCase):
             self.assertEqual(fqdn, vm.fqdn)
             self.assertEqual(vm.dataset_obj.is_dirty(), False)
 
-    def check_vm_absent(self, vm_name=VM_HOSTNAME, hv_name=None):
+    def check_vm_absent(self, vm_name=VM_HOSTNAME, hv_name=None, vg_name=DEFAULT_VG_NAME):
         # Operate on fresh object
         with _get_vm(vm_name, allow_retired=True) as vm:
             if self.datacenter_type == 'kvm.dct':
@@ -188,7 +188,7 @@ class IGVMTest(TestCase):
                         self.assertEqual(hv.vm_defined(vm), False)
                         hv.run(
                             'test ! -b /dev/{}/{}'.format(
-                                VG_NAME, self.uid_name)
+                                vg_name, self.uid_name)
                         )
             elif self.datacenter_type == 'aws.dct':
                 self.assertEqual(


### PR DESCRIPTION
Kind of related with NDCO-4920, this should allow us to build VMs on specific VGs.

Can be used to create mission-specific pools and assign VMs into it. As a first step it does not support migration, but that can be added later if need arise.