### PR TITLE
Use aws_reboot function instead of stopping and starting for a restart

### DIFF
--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -648,8 +648,7 @@ def vm_restart(vm_hostname, force=False, no_redefine=False):
     with ExitStack() as es:
         vm = es.enter_context(_get_vm(vm_hostname))
         if vm.dataset_obj['datacenter_type'] == 'aws.dct':
-            vm.aws_shutdown()
-            vm.aws_start()
+            vm.aws_restart()
         elif vm.dataset_obj['datacenter_type'] == 'kvm.dct':
             _check_defined(vm)
 

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -413,6 +413,30 @@ class VM(Host):
 
         if not host_up:
             raise VMError('The server is not reachable with SSH')
+        
+    def aws_restart(self):
+        """AWS restart
+
+        Restart a VM in AWS.
+        """
+
+        try:
+            self.ec2c.reboot_instances(
+                InstanceIds=[self.dataset_obj['aws_instance_id']],
+                DryRun=False
+            )
+    
+        except ClientError as e:
+            raise VMError(e)
+
+        host_up = wait_until(
+            str(self.dataset_obj['intern_ip']),
+            waitmsg='Waiting for SSH to respond',
+            timeout=180
+        )
+
+        if not host_up:
+            raise VMError('The server is not reachable with SSH')
 
     def shutdown(self, check_vm_up_on_transaction=True, transaction=None):
         self.hypervisor.stop_vm(self)


### PR DESCRIPTION
Restarting an instance in AWS by using the stop and start function might lead to "Insufficient instance capacity" Errors because a stopped instance isn't guaranteed to be available when you try to reboot it. [Docu](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/troubleshooting-launch.html#troubleshooting-launch-capacity)

> You get the InsufficientInstanceCapacity error when you try to launch a new instance or restart a stopped instance.

This PR uses the native reboot function via the API, which won't stop the VM.