### PR TITLE
preparations for debian trixie

### DIFF
--- a/igvm/host.py
+++ b/igvm/host.py
@@ -4,7 +4,7 @@ Copyright (c) 2018 InnoGames GmbH
 """
 
 from io import BytesIO
-from datetime import datetime
+from datetime import datetime, timezone
 
 import fabric.api
 import fabric.state
@@ -147,7 +147,7 @@ class Host(object):
                 .format(self.dataset_obj['hostname'])
             )
 
-        self.dataset_obj['igvm_locked'] = datetime.utcnow()
+        self.dataset_obj['igvm_locked'] = datetime.now(timezone.utc)
         try:
             self.dataset_obj.commit()
         except DatasetError:

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,2 +1,0 @@
--r requirements.txt
-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ netaddr~=0.8
 cffi~=1.14
 paramiko~=2.7
 Fabric3~=1.14
-libvirt-python>=7,<=9
+libvirt-python>=7,<=11
 jinja2~=2.11
 markupsafe~=1.1
 boto3~=1.26

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,7 +110,7 @@ def clean_hv(hv, pattern):
 
     # Cleanup igvm_locked status after a timeout
     if hv.dataset_obj['igvm_locked'] is not None:
-        now = datetime.utcnow().replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
         diff = now - hv.dataset_obj['igvm_locked']
 
         if diff >= IGVM_LOCKED_TIMEOUT:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,7 +14,7 @@ from adminapi.dataset import Query
 from adminapi.filters import Any
 from fabric.api import env
 from fabric.network import disconnect_all
-from mock import patch
+from unittest.mock import patch
 
 from igvm.commands import (
     _get_vm,


### PR DESCRIPTION
- avoid deprecation warning in datetime
- replace mock
- allow libvirt-python to to version 11