### PR TITLE
Migrate old "Fabric3" -> "fabric" version 3.2 

### DIFF
--- a/igvm/__init__.py
+++ b/igvm/__init__.py
@@ -3,4 +3,4 @@
 Copyright (c) 2024 InnoGames GmbH
 """
 
-VERSION = (2, 2, 5)
+VERSION = (2, 3, 0)

--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -60,7 +60,7 @@ class IGVMArgumentParser(ArgumentParser):
                 out.append(ColorFormatters.BOLD.format(choice))
                 if subparser.get_default('func').__doc__:
                     out.append('\n'.join(
-                        '\t{}'.format(line.strip()) for line in subparser
+                        f'\t{line.strip()}' for line in subparser
                         .get_default('func').__doc__.strip().splitlines()
                     ))
                 out.append('\n\t{}'.format(subparser.format_usage()))

--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -60,7 +60,7 @@ class IGVMArgumentParser(ArgumentParser):
                 out.append(ColorFormatters.BOLD.format(choice))
                 if subparser.get_default('func').__doc__:
                     out.append('\n'.join(
-                        '\t{}'.format(l.strip()) for l in subparser
+                        '\t{}'.format(line.strip()) for line in subparser
                         .get_default('func').__doc__.strip().splitlines()
                     ))
                 out.append('\n\t{}'.format(subparser.format_usage()))

--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser, _SubParsersAction
 from logging import StreamHandler, root as root_logger
 import time
 
-from igvm.host import disconnect_all
+from igvm.fabric_compat import disconnect_all
 
 from igvm.commands import (
     change_address,

--- a/igvm/cli.py
+++ b/igvm/cli.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser, _SubParsersAction
 from logging import StreamHandler, root as root_logger
 import time
 
-from fabric.network import disconnect_all
+from igvm.host import disconnect_all
 
 from igvm.commands import (
     change_address,
@@ -495,9 +495,8 @@ def main():
     try:
         args.pop('func')(**args)
     finally:
-        # Fabric requires the disconnect function to be called after every
-        # use.  We are also taking our chance to disconnect from
-        # the hypervisors.
+        # Disconnect all SSH connections.  We are also taking our chance
+        # to disconnect from the hypervisors.
         disconnect_all()
         close_virtconns()
 

--- a/igvm/colors.py
+++ b/igvm/colors.py
@@ -1,0 +1,28 @@
+"""igvm - Color output helpers
+
+Copyright (c) 2026 InnoGames GmbH
+
+Replacement for fabric.colors which is not available in fabric 3.x.
+"""
+
+
+def _wrap(code: int, text: str, bold: bool = False) -> str:
+    if bold:
+        return '\033[1;{}m{}\033[0m'.format(code, text)
+    return '\033[{}m{}\033[0m'.format(code, text)
+
+
+def green(text: str, bold: bool = False) -> str:
+    return _wrap(32, text, bold)
+
+
+def red(text: str, bold: bool = False) -> str:
+    return _wrap(31, text, bold)
+
+
+def yellow(text: str, bold: bool = False) -> str:
+    return _wrap(33, text, bold)
+
+
+def white(text: str, bold: bool = False) -> str:
+    return _wrap(37, text, bold)

--- a/igvm/colors.py
+++ b/igvm/colors.py
@@ -8,8 +8,8 @@ Replacement for fabric.colors which is not available in fabric 3.x.
 
 def _wrap(code: int, text: str, bold: bool = False) -> str:
     if bold:
-        return '\033[1;{}m{}\033[0m'.format(code, text)
-    return '\033[{}m{}\033[0m'.format(code, text)
+        return f'\033[1;{code}m{text}\033[0m'
+    return f'\033[{code}m{text}\033[0m'
 
 
 def green(text: str, bold: bool = False) -> str:

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -15,8 +15,8 @@ from typing import List, Optional
 from adminapi import parse
 from adminapi.dataset import Query, DatasetError
 from adminapi.filters import Any, BaseFilter, StartsWith, Contains
-from fabric.colors import green, red, white, yellow
-from fabric.network import disconnect_all
+from igvm.colors import green, red, white, yellow
+from igvm.host import disconnect_all
 from jinja2 import Environment, PackageLoader
 from libvirt import libvirtError
 
@@ -28,7 +28,6 @@ from igvm.exceptions import (
     InconsistentAttributeError,
     InvalidStateError, NetworkError,
 )
-from igvm.host import with_fabric_settings
 from igvm.hypervisor import Hypervisor
 from igvm.hypervisor_preferences import sort_by_preference
 from igvm.settings import (
@@ -63,7 +62,7 @@ def _check_defined(vm, fail_hard=True):
             log.info(error)
 
 
-@with_fabric_settings
+
 def evacuate(
     hv_hostname: str,
     target_hv_query: Optional[str] = None,
@@ -121,7 +120,7 @@ def evacuate(
             )
 
 
-@with_fabric_settings
+
 def vcpu_set(vm_hostname, count, offline=False):
     """Change the number of CPUs in a VM"""
     with ExitStack() as es:
@@ -182,7 +181,6 @@ def vcpu_set(vm_hostname, count, offline=False):
             vm.start()
 
 
-@with_fabric_settings
 def mem_set(vm_hostname, size, offline=False):
     """Change the memory size of a VM
 
@@ -231,7 +229,6 @@ def mem_set(vm_hostname, size, offline=False):
             vm.start()
 
 
-@with_fabric_settings
 def disk_set(vm_hostname, size):
     """Change the disk size of a VM
 
@@ -272,7 +269,6 @@ def disk_set(vm_hostname, size):
         vm.dataset_obj.commit()
 
 
-@with_fabric_settings
 def change_address(
     vm_hostname, new_address,
     offline=False, migrate=False, allow_reserved_hv=False,
@@ -351,7 +347,6 @@ def change_address(
                 vm.start()
 
 
-@with_fabric_settings
 def vm_build(
     vm_hostname: str,
     run_puppet: bool = True,
@@ -455,7 +450,6 @@ def vm_build(
         vm.dataset_obj.commit()
 
 
-@with_fabric_settings  # NOQA: C901
 def vm_migrate(
     vm_hostname: str = None,
     vm_object=None,
@@ -616,7 +610,6 @@ def vm_migrate(
         previous_hypervisor.undefine_vm(_vm)
 
 
-@with_fabric_settings
 def vm_start(vm_hostname):
     """Start a VM"""
     with _get_vm(vm_hostname) as vm:
@@ -635,7 +628,6 @@ def vm_start(vm_hostname):
             )
 
 
-@with_fabric_settings
 def vm_stop(vm_hostname, force=False):
     """Gracefully stop a VM"""
     with _get_vm(vm_hostname, allow_retired=True) as vm:
@@ -660,7 +652,6 @@ def vm_stop(vm_hostname, force=False):
         log.info('"{}" is stopped.'.format(vm.fqdn))
 
 
-@with_fabric_settings
 def vm_restart(vm_hostname, force=False, no_redefine=False):
     """Restart a VM
 
@@ -696,7 +687,6 @@ def vm_restart(vm_hostname, force=False, no_redefine=False):
         log.info('"{}" is restarted.'.format(vm.fqdn))
 
 
-@with_fabric_settings
 def vm_delete(vm_hostname, retire=False):
     """Delete the VM from the hypervisor and from serveradmin
 
@@ -762,7 +752,6 @@ def vm_delete(vm_hostname, retire=False):
             )
 
 
-@with_fabric_settings
 def vm_sync(vm_hostname):
     """Synchronize VM resource attributes to Serveradmin
 
@@ -822,7 +811,6 @@ def vm_define(vm_hostname):
         vm_hostname, vm_dataset_obj['hypervisor']['hostname']))
 
 
-@with_fabric_settings  # NOQA: C901
 def host_info(vm_hostname):
     """Extract runtime information about a VM
 
@@ -933,7 +921,6 @@ def host_info(vm_hostname):
                 print('{} : {}'.format(k.ljust(max_key_len), value))
 
 
-@with_fabric_settings
 def vm_rename(vm_hostname, new_hostname, offline=False):
     """Redefine the VM on the same hypervisor with a different name
 
@@ -971,7 +958,6 @@ def vm_rename(vm_hostname, new_hostname, offline=False):
             vm.aws_rename(new_hostname)
 
 
-@with_fabric_settings
 def clean_cert(hostname: str):
     """Revoke and delete a Puppet certificate from the Puppet CA"""
     vm = Query({'hostname': hostname}, ['hostname', 'puppet_ca']).get()

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -16,7 +16,7 @@ from adminapi import parse
 from adminapi.dataset import Query, DatasetError
 from adminapi.filters import Any, BaseFilter, StartsWith, Contains
 from igvm.colors import green, red, white, yellow
-from igvm.host import disconnect_all
+from igvm.fabric_compat import disconnect_all
 from jinja2 import Environment, PackageLoader
 from libvirt import libvirtError
 

--- a/igvm/commands.py
+++ b/igvm/commands.py
@@ -62,7 +62,6 @@ def _check_defined(vm, fail_hard=True):
             log.info(error)
 
 
-
 def evacuate(
     hv_hostname: str,
     target_hv_query: Optional[str] = None,
@@ -118,7 +117,6 @@ def evacuate(
                 allow_reserved_hv=allow_reserved_hv,
                 soft_preferences=soft_preferences,
             )
-
 
 
 def vcpu_set(vm_hostname, count, offline=False):
@@ -507,7 +505,7 @@ def vm_migrate(
             # likely that a specific hypervisor was requested. Any other filter
             # could resolve to multiple HVs.
             and (not isinstance(hv_filter['hostname'], BaseFilter)
-                 or type(hv_filter['hostname']) == BaseFilter)
+                 or type(hv_filter['hostname']) is BaseFilter)
         ):
             hypervisor = es.enter_context(_get_hypervisor(
                 hv_filter['hostname'],

--- a/igvm/drbd.py
+++ b/igvm/drbd.py
@@ -3,7 +3,6 @@
 Copyright (c) 2018 InnoGames GmbH
 """
 
-from adminapi import api
 from contextlib import contextmanager
 from igvm.exceptions import RemoteCommandError
 from igvm.settings import DEFAULT_VG_NAME
@@ -188,7 +187,6 @@ class DRBD(object):
                 addr=self.hv.dataset_obj['intern_ip'],
                 port=self.get_device_port(),
                 dm_minor=self.get_device_minor(),
-                lv_name=self.lv_name,
                 disk=(
                     'mapper/{}_orig'.format(self.lv_name)
                     if self.master_role

--- a/igvm/fabric_compat.py
+++ b/igvm/fabric_compat.py
@@ -2,24 +2,15 @@
 
 Copyright (c) 2026 InnoGames GmbH
 
-igvm targets the modern ``fabric`` 3.x (Invoke/Paramiko based,
-``fabric.Connection`` object API).  Some deployment hosts still have the old
-``fabric3`` package installed instead — a Python-3 fork of Fabric 1.x with a
-completely different, global-``env`` based ``fabric.api`` API.  Both packages
-import as ``fabric`` and cannot be co-installed, so the modern-only code would
-crash on a fabric3 host with ``AttributeError: module 'fabric' has no attribute
-'Connection'``.
+igvm targets modern ``fabric`` 3.x (the ``fabric.Connection`` object API), but
+some hosts still have old ``fabric3`` (a Py3 fork of Fabric 1.x, global
+``fabric.api``).  Both import as ``fabric`` and can't be co-installed, so this
+module detects the flavor at import and exposes one surface (``Connection``,
+``make_fabric_config``, ``disconnect_all``, ``IS_LEGACY_FABRIC``) — a thin
+passthrough on modern fabric, a small ``fabric.api`` adapter on fabric3.
 
-This module detects which flavor is installed at import time and exposes a
-single, uniform surface (``Connection``, ``make_fabric_config``,
-``disconnect_all``, ``IS_LEGACY_FABRIC``) that the rest of igvm uses instead of
-``import fabric``.  On modern fabric everything is a thin passthrough; on legacy
-fabric3 a small adapter reproduces the pre-migration behavior on top of
-``fabric.api``.
-
-The fabric3 support is meant to be short-lived.  All fabric3-specific code lives
-here, gated by ``IS_LEGACY_FABRIC``, so it can be deleted as a clean revert once
-every host runs modern fabric.
+Short-lived: all fabric3 code is gated by ``IS_LEGACY_FABRIC`` so it can be
+deleted as a clean revert once every host runs modern fabric.
 """
 
 from sys import stdout
@@ -28,11 +19,9 @@ import fabric
 
 from igvm.exceptions import RemoteCommandError
 
-# Sudo prompt format expected by the SSH_ORIGINAL_COMMAND whitelists on remote
-# hosts.  Fabric 1.x (fabric3) used 'sudo password:'; modern fabric defaults to
-# '[sudo] password:', so on modern fabric we override it back.  Defined here
-# (rather than in settings.py) so the shim has no dependency on igvm.settings,
-# which itself imports this module.
+# Sudo prompt the remote SSH_ORIGINAL_COMMAND whitelists expect.  fabric3 used
+# 'sudo password:'; modern fabric defaults to '[sudo] password:', so force it
+# back.  Kept out of settings.py so the shim needs no igvm.settings import.
 FABRIC_SUDO_PROMPT = 'sudo password:'
 
 # Modern fabric exposes fabric.Connection / fabric.Config; fabric3 does not.
@@ -67,8 +56,7 @@ else:
     # Make fabric3's sudo prompt match the whitelist format.
     fabric.api.env.sudo_prompt = FABRIC_SUDO_PROMPT
 
-    # The same global settings the pre-migration code used (see git master
-    # igvm/settings.py COMMON_FABRIC_SETTINGS / igvm/host.py).
+    # The global settings the pre-migration code used (git master settings.py).
     _COMMON_FABRIC_SETTINGS = dict(
         disable_known_hosts=True,
         use_ssh_config=True,
@@ -81,13 +69,9 @@ else:
     )
 
     class _LegacyConfig:
-        """Lightweight stand-in for fabric.Config on fabric3.
-
-        fabric3 has no per-connection config object; the sudo prompt is set
-        globally on ``fabric.api.env`` (done at import above).  This carrier
-        merely lets call sites keep passing ``config=make_fabric_config()``
-        uniformly.
-        """
+        """Stand-in for fabric.Config on fabric3 (no per-connection config; the
+        sudo prompt is global, set at import).  Lets call sites keep passing
+        ``config=make_fabric_config()`` uniformly."""
 
         def __init__(self):
             self.sudo = {'prompt': FABRIC_SUDO_PROMPT}
@@ -96,13 +80,9 @@ else:
         return _LegacyConfig()
 
     class _LegacyResult:
-        """Expose modern invoke.Result attributes over a fabric3 result.
-
-        A fabric3 run()/sudo() result is a str subclass that *is* the stdout,
-        carrying ``.return_code``, ``.failed``, ``.succeeded`` and ``.stderr``.
-        igvm (and host.CommandResult) read ``.stdout/.stderr/.return_code/.ok/
-        .failed``, so we map the names that differ.
-        """
+        """Map a fabric3 result (a str that *is* stdout, with .return_code/
+        .failed/.succeeded/.stderr) onto the invoke.Result names igvm reads
+        (.stdout/.stderr/.return_code/.ok/.failed)."""
 
         def __init__(self, result):
             self._result = result
@@ -128,13 +108,10 @@ else:
             return self._result.failed
 
     class _LegacyConnection:
-        """Subset of the modern fabric.Connection API over fabric3.
-
-        fabric3 has no persistent per-host connection object: ``env`` is global
-        and connections live in the global ``fabric.state.connections`` pool.
-        Each method therefore opens a ``fabric.api.settings(host_string=...)``
-        block per call, exactly as the pre-migration Host.run() did.
-        """
+        """Subset of modern fabric.Connection over fabric3, whose env and
+        connections are global.  Each call opens a
+        ``fabric.api.settings(host_string=...)`` block, as pre-migration
+        Host.run() did."""
 
         def __init__(self, host, config=None, user=None, connect_timeout=None,
                      connect_kwargs=None, **_ignored):

--- a/igvm/fabric_compat.py
+++ b/igvm/fabric_compat.py
@@ -1,0 +1,226 @@
+"""igvm - Fabric compatibility shim
+
+Copyright (c) 2026 InnoGames GmbH
+
+igvm targets the modern ``fabric`` 3.x (Invoke/Paramiko based,
+``fabric.Connection`` object API).  Some deployment hosts still have the old
+``fabric3`` package installed instead — a Python-3 fork of Fabric 1.x with a
+completely different, global-``env`` based ``fabric.api`` API.  Both packages
+import as ``fabric`` and cannot be co-installed, so the modern-only code would
+crash on a fabric3 host with ``AttributeError: module 'fabric' has no attribute
+'Connection'``.
+
+This module detects which flavor is installed at import time and exposes a
+single, uniform surface (``Connection``, ``make_fabric_config``,
+``disconnect_all``, ``IS_LEGACY_FABRIC``) that the rest of igvm uses instead of
+``import fabric``.  On modern fabric everything is a thin passthrough; on legacy
+fabric3 a small adapter reproduces the pre-migration behavior on top of
+``fabric.api``.
+
+The fabric3 support is meant to be short-lived.  All fabric3-specific code lives
+here, gated by ``IS_LEGACY_FABRIC``, so it can be deleted as a clean revert once
+every host runs modern fabric.
+"""
+
+from sys import stdout
+
+import fabric
+
+from igvm.exceptions import RemoteCommandError
+
+# Sudo prompt format expected by the SSH_ORIGINAL_COMMAND whitelists on remote
+# hosts.  Fabric 1.x (fabric3) used 'sudo password:'; modern fabric defaults to
+# '[sudo] password:', so on modern fabric we override it back.  Defined here
+# (rather than in settings.py) so the shim has no dependency on igvm.settings,
+# which itself imports this module.
+FABRIC_SUDO_PROMPT = 'sudo password:'
+
+# Modern fabric exposes fabric.Connection / fabric.Config; fabric3 does not.
+IS_LEGACY_FABRIC = not hasattr(fabric, 'Connection')
+
+# Registry of active connections, used by the modern disconnect_all().
+_active_connections = set()
+
+
+if not IS_LEGACY_FABRIC:
+    # ----------------------------------------------------------------- modern
+    Connection = fabric.Connection
+
+    def make_fabric_config():
+        return fabric.Config(overrides={'sudo': {'prompt': FABRIC_SUDO_PROMPT}})
+
+    def disconnect_all():
+        """Close all tracked SSH connections."""
+        for conn in list(_active_connections):
+            try:
+                conn.close()
+            except Exception:
+                pass
+        _active_connections.clear()
+
+else:
+    # ----------------------------------------------------------------- legacy
+    import fabric.api
+    import fabric.network
+    import fabric.state
+
+    # Make fabric3's sudo prompt match the whitelist format.
+    fabric.api.env.sudo_prompt = FABRIC_SUDO_PROMPT
+
+    # The same global settings the pre-migration code used (see git master
+    # igvm/settings.py COMMON_FABRIC_SETTINGS / igvm/host.py).
+    _COMMON_FABRIC_SETTINGS = dict(
+        disable_known_hosts=True,
+        use_ssh_config=True,
+        always_use_pty=stdout.isatty(),
+        forward_agent=True,
+        shell='/bin/sh -c',
+        timeout=5,
+        connection_attempts=3,
+        remote_interrupt=True,
+    )
+
+    class _LegacyConfig:
+        """Lightweight stand-in for fabric.Config on fabric3.
+
+        fabric3 has no per-connection config object; the sudo prompt is set
+        globally on ``fabric.api.env`` (done at import above).  This carrier
+        merely lets call sites keep passing ``config=make_fabric_config()``
+        uniformly.
+        """
+
+        def __init__(self):
+            self.sudo = {'prompt': FABRIC_SUDO_PROMPT}
+
+    def make_fabric_config():
+        return _LegacyConfig()
+
+    class _LegacyResult:
+        """Expose modern invoke.Result attributes over a fabric3 result.
+
+        A fabric3 run()/sudo() result is a str subclass that *is* the stdout,
+        carrying ``.return_code``, ``.failed``, ``.succeeded`` and ``.stderr``.
+        igvm (and host.CommandResult) read ``.stdout/.stderr/.return_code/.ok/
+        .failed``, so we map the names that differ.
+        """
+
+        def __init__(self, result):
+            self._result = result
+
+        @property
+        def stdout(self):
+            return str(self._result)
+
+        @property
+        def stderr(self):
+            return getattr(self._result, 'stderr', '') or ''
+
+        @property
+        def return_code(self):
+            return self._result.return_code
+
+        @property
+        def ok(self):
+            return self._result.succeeded
+
+        @property
+        def failed(self):
+            return self._result.failed
+
+    class _LegacyConnection:
+        """Subset of the modern fabric.Connection API over fabric3.
+
+        fabric3 has no persistent per-host connection object: ``env`` is global
+        and connections live in the global ``fabric.state.connections`` pool.
+        Each method therefore opens a ``fabric.api.settings(host_string=...)``
+        block per call, exactly as the pre-migration Host.run() did.
+        """
+
+        def __init__(self, host, config=None, user=None, connect_timeout=None,
+                     connect_kwargs=None, **_ignored):
+            self.host = str(host)
+            self.user = user
+            self._closed = False
+
+        @property
+        def is_connected(self):
+            if self._closed:
+                return False
+            try:
+                return self.host in fabric.state.connections
+            except Exception:
+                return False
+
+        def _base_settings(self):
+            settings = dict(_COMMON_FABRIC_SETTINGS)
+            if self.user:
+                settings['user'] = self.user
+            # Backstop for non-warn paths (get/put); run/sudo set warn_only.
+            settings['abort_exception'] = RemoteCommandError
+            return settings
+
+        def _execute(self, func, command, hide, warn, pty, shell, extra_kwargs):
+            settings = self._base_settings()
+            settings['warn_only'] = bool(warn)
+
+            ctx = []
+            if hide:
+                # igvm only ever passes hide=True (suppress everything).
+                ctx.append(fabric.api.hide('everything'))
+
+            call_kwargs = dict(extra_kwargs)
+            if pty is not None:
+                call_kwargs['pty'] = pty
+            if shell == '':
+                # Modern "don't wrap in a shell" -> fabric3 shell=False.
+                call_kwargs['shell'] = False
+
+            with fabric.api.settings(*ctx, host_string=self.host, **settings):
+                result = func(command, **call_kwargs)
+
+            self._closed = False
+            return _LegacyResult(result)
+
+        def run(self, command, hide=False, warn=False, pty=None, shell=None,
+                **kwargs):
+            return self._execute(
+                fabric.api.run, command, hide, warn, pty, shell, kwargs,
+            )
+
+        def sudo(self, command, hide=False, warn=False, pty=None, shell=None,
+                 **kwargs):
+            return self._execute(
+                fabric.api.sudo, command, hide, warn, pty, shell, kwargs,
+            )
+
+        def get(self, remote, local):
+            settings = self._base_settings()
+            with fabric.api.settings(
+                fabric.api.hide('commands'), host_string=self.host, **settings,
+            ):
+                return fabric.api.get(remote, local)
+
+        def put(self, local, remote):
+            settings = self._base_settings()
+            with fabric.api.settings(host_string=self.host, **settings):
+                return fabric.api.put(local, remote)
+
+        def close(self):
+            self._closed = True
+            try:
+                connections = fabric.state.connections
+                if self.host in connections:
+                    connections[self.host].get_transport().close()
+                    del connections[self.host]
+            except Exception:
+                pass
+
+    Connection = _LegacyConnection
+
+    def disconnect_all():
+        """Close all SSH connections from fabric3's global pool."""
+        try:
+            fabric.network.disconnect_all()
+        except Exception:
+            pass
+        _active_connections.clear()

--- a/igvm/host.py
+++ b/igvm/host.py
@@ -3,29 +3,70 @@
 Copyright (c) 2018 InnoGames GmbH
 """
 
-from io import BytesIO
+import logging
+import socket
 from datetime import datetime
-
-import fabric.api
-import fabric.state
-from fabric.contrib import files
+from io import BytesIO
 from uuid import uuid4
 
-from paramiko import transport
+import fabric
+import paramiko.ssh_exception
+
 from igvm.exceptions import RemoteCommandError, InvalidStateError
-from igvm.settings import COMMON_FABRIC_SETTINGS
+from igvm.settings import (
+    FABRIC_CONNECTION_ATTEMPTS,
+    FABRIC_CONNECTION_DEFAULTS,
+    FABRIC_RUN_DEFAULTS,
+)
 
 from adminapi.dataset import DatasetError
 
+log = logging.getLogger(__name__)
 
-def with_fabric_settings(fn):
-    """Decorator to run a function with COMMON_FABRIC_SETTINGS."""
-    def decorator(*args, **kwargs):
-        with fabric.api.settings(**COMMON_FABRIC_SETTINGS):
-            return fn(*args, **kwargs)
-    decorator.__name__ = '{}_with_fabric'.format(fn.__name__)
-    decorator.__doc__ = fn.__doc__
-    return decorator
+# Registry of active connections for disconnect_all()
+_active_connections = set()
+
+
+class CommandResult(str):
+    """String subclass wrapping invoke.runners.Result for backward compat.
+
+    Fabric 1.x run()/sudo() returned a string-like object.  Fabric 3.x
+    returns invoke.runners.Result.  This wrapper lets callers keep using
+    .strip(), int(result), 'text' in result, etc. while also exposing
+    .ok, .failed, .return_code, .stdout, .stderr.
+    """
+
+    def __new__(cls, result):
+        stdout = result.stdout if result.stdout else ''
+        instance = super().__new__(cls, stdout)
+        instance._result = result
+        return instance
+
+    @property
+    def return_code(self):
+        return self._result.return_code
+
+    @property
+    def ok(self):
+        return self._result.ok
+
+    @property
+    def failed(self):
+        return self._result.failed
+
+    @property
+    def stdout(self):
+        return self._result.stdout if self._result.stdout else ''
+
+
+def disconnect_all():
+    """Close all tracked SSH connections."""
+    for conn in list(_active_connections):
+        try:
+            conn.close()
+        except Exception:
+            pass
+    _active_connections.clear()
 
 
 class Host(object):
@@ -35,6 +76,7 @@ class Host(object):
         self.dataset_obj = dataset_obj
         self.route_network = dataset_obj['route_network']['hostname']
         self.fqdn = self.dataset_obj['hostname']    # TODO: Remove
+        self._connection = None
 
     def __str__(self):
         return self.fqdn
@@ -61,69 +103,120 @@ class Host(object):
         """Check if a given uid_name matches this host"""
         return uid_name.split('_', 1)[0] == str(self.dataset_obj['object_id'])
 
-    def fabric_settings(self, *args, **kwargs):
-        """Builds a fabric context manager to run commands on this host."""
-        settings = COMMON_FABRIC_SETTINGS.copy()
-        settings.update({
-            'abort_exception': RemoteCommandError,
-            'host_string': str(self.dataset_obj['hostname']),
-        })
-        settings.update(kwargs)
-        return fabric.api.settings(*args, **settings)
+    def _get_connection(self):
+        """Return a cached fabric.Connection for this host."""
+        if self._connection is None or not self._connection.is_connected:
+            hostname = str(self.dataset_obj['hostname'])
+            self._connection = fabric.Connection(
+                hostname, **FABRIC_CONNECTION_DEFAULTS
+            )
+            _active_connections.add(self._connection)
+        return self._connection
+
+    def close_connection(self):
+        """Close and discard the cached connection."""
+        if self._connection is not None:
+            try:
+                self._connection.close()
+            except Exception:
+                pass
+            _active_connections.discard(self._connection)
+            self._connection = None
 
     def run(self, *args, **kwargs):
         """Runs a command on the remote host.
         :param warn_only: If set, no exception is raised if the command fails
         :param silent: If set, no output is written for successful runs"""
-        settings = []
-        warn_only = kwargs.get('warn_only', False)
-        with_sudo = kwargs.get('with_sudo', True)
-        kwargs['pty'] = kwargs.get('pty', True)
-        if kwargs.get('silent', False):
-            hide = 'everything' if warn_only else 'commands'
-            settings.append(fabric.api.hide(hide))
+        warn_only = kwargs.pop('warn_only', False)
+        with_sudo = kwargs.pop('with_sudo', True)
+        silent = kwargs.pop('silent', False)
 
-        # Purge settings that should not be passed to run()
-        for setting in ['warn_only', 'silent', 'with_sudo']:
-            if setting in kwargs:
-                del kwargs[setting]
+        # Build run kwargs
+        run_kwargs = dict(FABRIC_RUN_DEFAULTS)
+        run_kwargs['pty'] = kwargs.pop('pty', run_kwargs.get('pty', True))
+        run_kwargs['warn'] = warn_only
 
-        with self.fabric_settings(*settings, warn_only=warn_only):
+        if silent:
+            run_kwargs['hide'] = True
+
+        # Pass through any remaining kwargs (e.g. shell, shell_escape)
+        # Map shell_escape to Fabric 3.x equivalent if present
+        kwargs.pop('shell_escape', None)
+
+        # 'shell' kwarg: In Fabric 1.x, shell=False meant don't wrap in shell.
+        # In Fabric 3.x/invoke, the equivalent is setting shell to empty string
+        # or using the command directly. We'll pass it through.
+        if 'shell' in kwargs:
+            shell_val = kwargs.pop('shell')
+            if shell_val is False:
+                run_kwargs['shell'] = ''
+
+        run_kwargs.update(kwargs)
+
+        # Remove abort_exception if present (Fabric 1.x only)
+        run_kwargs.pop('abort_exception', None)
+
+        conn = self._get_connection()
+        runner = conn.sudo if with_sudo else conn.run
+
+        for attempt in range(FABRIC_CONNECTION_ATTEMPTS):
             try:
-                if with_sudo:
-                    return fabric.api.sudo(*args, **kwargs)
+                result = runner(*args, **run_kwargs)
+                if not warn_only and result.failed:
+                    raise RemoteCommandError(
+                        'Command failed with return code {}: {}'.format(
+                            result.return_code, args[0] if args else ''
+                        )
+                    )
+                return CommandResult(result)
+            except (
+                paramiko.ssh_exception.SSHException,
+                paramiko.ssh_exception.NoValidConnectionsError,
+                socket.error,
+                EOFError,
+            ):
+                if attempt < FABRIC_CONNECTION_ATTEMPTS - 1:
+                    log.warning(
+                        'Connection lost, retrying (attempt %d/%d)...',
+                        attempt + 2, FABRIC_CONNECTION_ATTEMPTS,
+                    )
+                    self.close_connection()
+                    conn = self._get_connection()
+                    runner = conn.sudo if with_sudo else conn.run
                 else:
-                    return fabric.api.run(*args, **kwargs)
-            except transport.socket.error:
-                # Retry once if connection was lost
-                host = fabric.api.env.host_string
-                if host and host in fabric.state.connections:
-                    fabric.state.connections[host].get_transport().close()
-                if with_sudo:
-                    return fabric.api.sudo(*args, **kwargs)
-                else:
-                    return fabric.api.run(*args, **kwargs)
+                    raise
 
-    def file_exists(self, *args, **kwargs):
-        """Run a fabric.contrib.files.exists on this host with sudo."""
-        with self.fabric_settings():
+    def file_exists(self, path, *args, **kwargs):
+        """Check if a file exists on the remote host."""
+        conn = self._get_connection()
+
+        for attempt in range(FABRIC_CONNECTION_ATTEMPTS):
             try:
-                return files.exists(*args, **kwargs)
-            except transport.socket.error:
-                # Retry once if connection was lost
-                host = fabric.api.env.host_string
-                if host and host in fabric.state.connections:
-                    fabric.state.connections[host].get_transport().close()
-                return files.exists(*args, **kwargs)
+                result = conn.sudo(
+                    'test -e {}'.format(path),
+                    warn=True, hide=True,
+                )
+                return result.ok
+            except (
+                paramiko.ssh_exception.SSHException,
+                paramiko.ssh_exception.NoValidConnectionsError,
+                socket.error,
+                EOFError,
+            ):
+                if attempt < FABRIC_CONNECTION_ATTEMPTS - 1:
+                    self.close_connection()
+                    conn = self._get_connection()
+                else:
+                    raise
 
     def read_file(self, path):
         """Reads a file from the remote host and returns contents."""
         if '*' in path:
             raise ValueError('No globbing supported')
-        with self.fabric_settings(fabric.api.hide('commands')):
-            fd = BytesIO()
-            fabric.api.get(path, fd)
-            return fd.getvalue()
+        conn = self._get_connection()
+        fd = BytesIO()
+        conn.get(path, fd)
+        return fd.getvalue()
 
     def put(self, remote_path, local_path, mode='0644'):
         """Same as Fabric's put but with working sudo permissions
@@ -132,13 +225,13 @@ class Host(object):
         broken, at least for mounted VM.  This is why we run extra commands
         in here.
         """
-        with self.fabric_settings():
-            tempfile = '/tmp/' + str(uuid4())
-            fabric.api.put(local_path, tempfile)
-            self.run(
-                'mv {0} {1} ; chmod {2} {1}'
-                .format(tempfile, remote_path, mode)
-            )
+        conn = self._get_connection()
+        tempfile = '/tmp/' + str(uuid4())
+        conn.put(local_path, tempfile)
+        self.run(
+            'mv {0} {1} ; chmod {2} {1}'
+            .format(tempfile, remote_path, mode)
+        )
 
     def acquire_lock(self, allow_fail=False):
         if self.dataset_obj['igvm_locked'] is not None:

--- a/igvm/host.py
+++ b/igvm/host.py
@@ -10,12 +10,16 @@ from datetime import datetime, timezone
 from io import BytesIO
 from uuid import uuid4
 
-import fabric
 import paramiko.ssh_exception
 
 from igvm.exceptions import RemoteCommandError, InvalidStateError
-from igvm.settings import (
+from igvm.fabric_compat import (
+    Connection,
+    IS_LEGACY_FABRIC,
     make_fabric_config,
+    _active_connections,
+)
+from igvm.settings import (
     FABRIC_CONNECTION_ATTEMPTS,
     FABRIC_CONNECTION_DEFAULTS,
     FABRIC_RUN_DEFAULTS,
@@ -24,9 +28,6 @@ from igvm.settings import (
 from adminapi.dataset import DatasetError
 
 log = logging.getLogger(__name__)
-
-# Registry of active connections for disconnect_all()
-_active_connections = set()
 
 
 class CommandResult(str):
@@ -69,16 +70,6 @@ class CommandResult(str):
         return self._result.stderr if self._result.stderr else ''
 
 
-def disconnect_all():
-    """Close all tracked SSH connections."""
-    for conn in list(_active_connections):
-        try:
-            conn.close()
-        except Exception:
-            pass
-    _active_connections.clear()
-
-
 class Host(object):
     """A remote host on which commands can be executed."""
 
@@ -117,7 +108,7 @@ class Host(object):
         """Return a cached fabric.Connection for this host."""
         if self._connection is None or not self._connection.is_connected:
             hostname = str(self.dataset_obj['hostname'])
-            self._connection = fabric.Connection(
+            self._connection = Connection(
                 hostname, config=make_fabric_config(), **FABRIC_CONNECTION_DEFAULTS
             )
             _active_connections.add(self._connection)
@@ -175,7 +166,8 @@ class Host(object):
         # command without wrapping it in a shell, unlike Fabric.
         # This breaks commands containing shell constructs (while, for, if,
         # pipes, etc.).  Wrap in "bash -c '...'" to restore the old behavior.
-        if with_sudo and args:
+        # Legacy fabric3 already shell-wraps sudo commands, so skip it there.
+        if with_sudo and args and not IS_LEGACY_FABRIC:
             cmd = args[0]
             args = (f"bash -c {shlex.quote(cmd)}",) + args[1:]
 

--- a/igvm/host.py
+++ b/igvm/host.py
@@ -6,7 +6,7 @@ Copyright (c) 2018 InnoGames GmbH
 import logging
 import shlex
 import socket
-from datetime import datetime
+from datetime import datetime, timezone
 from io import BytesIO
 from uuid import uuid4
 
@@ -202,25 +202,11 @@ class Host(object):
     def file_exists(self, path, *args, **kwargs):
         """Check if a file exists on the remote host."""
         conn = self._get_connection()
-
-        for attempt in range(FABRIC_CONNECTION_ATTEMPTS):
-            try:
-                result = conn.sudo(
-                    f'test -e {path}',
-                    warn=True, hide=True,
-                )
-                return result.ok
-            except (
-                paramiko.ssh_exception.SSHException,
-                paramiko.ssh_exception.NoValidConnectionsError,
-                socket.error,
-                EOFError,
-            ):
-                if attempt < FABRIC_CONNECTION_ATTEMPTS - 1:
-                    self.close_connection()
-                    conn = self._get_connection()
-                else:
-                    raise
+        result = conn.sudo(
+            f'test -e {path}',
+            warn=True, hide=True,
+        )
+        return result.ok
 
     def read_file(self, path):
         """Reads a file from the remote host and returns contents."""
@@ -245,14 +231,14 @@ class Host(object):
             f'mv {tempfile} {remote_path} ; chmod {mode} {remote_path}'
         )
 
-    def acquire_lock(self, allow_fail=False):
+    def acquire_lock(self):
         if self.dataset_obj['igvm_locked'] is not None:
             raise InvalidStateError(
                 'Server "{0}" is already being worked on by another igvm'
                 .format(self.dataset_obj['hostname'])
             )
 
-        self.dataset_obj['igvm_locked'] = datetime.utcnow()
+        self.dataset_obj['igvm_locked'] = datetime.now(timezone.utc)
         try:
             self.dataset_obj.commit()
         except DatasetError:

--- a/igvm/host.py
+++ b/igvm/host.py
@@ -15,6 +15,7 @@ import paramiko.ssh_exception
 
 from igvm.exceptions import RemoteCommandError, InvalidStateError
 from igvm.settings import (
+    make_fabric_config,
     FABRIC_CONNECTION_ATTEMPTS,
     FABRIC_CONNECTION_DEFAULTS,
     FABRIC_RUN_DEFAULTS,
@@ -62,6 +63,10 @@ class CommandResult(str):
     @property
     def stdout(self):
         return self._result.stdout if self._result.stdout else ''
+
+    @property
+    def stderr(self):
+        return self._result.stderr if self._result.stderr else ''
 
 
 def disconnect_all():
@@ -113,7 +118,7 @@ class Host(object):
         if self._connection is None or not self._connection.is_connected:
             hostname = str(self.dataset_obj['hostname'])
             self._connection = fabric.Connection(
-                hostname, **FABRIC_CONNECTION_DEFAULTS
+                hostname, config=make_fabric_config(), **FABRIC_CONNECTION_DEFAULTS
             )
             _active_connections.add(self._connection)
         return self._connection

--- a/igvm/host.py
+++ b/igvm/host.py
@@ -31,19 +31,14 @@ log = logging.getLogger(__name__)
 
 
 class CommandResult(str):
-    """String subclass wrapping invoke.runners.Result for backward compat.
-
-    Fabric 1.x run()/sudo() returned a string-like object.  Fabric 3.x
-    returns invoke.runners.Result.  This wrapper lets callers keep using
-    .strip(), int(result), 'text' in result, etc. while also exposing
-    .ok, .failed, .return_code, .stdout, .stderr.
+    """str subclass wrapping invoke.Result for backward compat: callers keep
+    using .strip()/int()/`in`, plus .ok/.failed/.return_code/.stdout/.stderr.
+    Fabric 1.x returned a string-like object; Fabric 3.x returns invoke.Result.
     """
 
     def __new__(cls, result):
-        # Fabric 1.x automatically stripped trailing whitespace from the
-        # string representation.  Fabric 3.x does not, so we strip here
-        # to avoid embedded newlines breaking commands that interpolate
-        # the result (e.g. mktemp output used as a mount path).
+        # Fabric 1.x stripped trailing whitespace; 3.x doesn't.  Strip here so
+        # interpolated output (e.g. mktemp as a mount path) has no newline.
         stdout = result.stdout.strip() if result.stdout else ''
         instance = super().__new__(cls, stdout)
         instance._result = result
@@ -105,11 +100,15 @@ class Host(object):
         return uid_name.split('_', 1)[0] == str(self.dataset_obj['object_id'])
 
     def _get_connection(self):
-        """Return a cached fabric.Connection for this host."""
-        if self._connection is None or not self._connection.is_connected:
+        """Return a cached fabric.Connection, built on first use.  fabric opens
+        it lazily (run/sudo/get/put are ``@opens``-decorated) and reuses it; a
+        dropped connection is cleared to None by run()'s retry loop, so the
+        next call rebuilds it."""
+        if self._connection is None:
             hostname = str(self.dataset_obj['hostname'])
             self._connection = Connection(
-                hostname, config=make_fabric_config(), **FABRIC_CONNECTION_DEFAULTS
+                hostname, config=make_fabric_config(),
+                **FABRIC_CONNECTION_DEFAULTS,
             )
             _active_connections.add(self._connection)
         return self._connection
@@ -132,23 +131,21 @@ class Host(object):
         with_sudo = kwargs.pop('with_sudo', True)
         silent = kwargs.pop('silent', False)
 
-        # Build run kwargs
         run_kwargs = dict(FABRIC_RUN_DEFAULTS)
         run_kwargs['pty'] = kwargs.pop('pty', run_kwargs.get('pty', True))
-        # Always suppress invoke's UnexpectedExit so we can raise our own
-        # RemoteCommandError instead (checked below after the call).
+        # Force warn=True so invoke never raises UnexpectedExit; we raise our
+        # own RemoteCommandError below instead.
         run_kwargs['warn'] = True
 
         if silent:
             run_kwargs['hide'] = True
 
-        # Pass through any remaining kwargs (e.g. shell, shell_escape)
-        # Map shell_escape to Fabric 3.x equivalent if present
+        # shell_escape was Fabric 1.x-only; drop it.
         kwargs.pop('shell_escape', None)
 
-        # 'shell' kwarg: In Fabric 1.x, shell=False meant don't wrap in shell.
-        # In Fabric 3.x/invoke, the equivalent is setting shell to empty string
-        # or using the command directly. We'll pass it through.
+        # Fabric 1.x shell=False ("don't add an extra /bin/sh -c") -> shell=''.
+        # Modern fabric's SSH runner ignores 'shell' (the bash -c wrap below
+        # does the real work); the fabric3 adapter maps '' back to shell=False.
         if 'shell' in kwargs:
             shell_val = kwargs.pop('shell')
             if shell_val is False:
@@ -162,11 +159,9 @@ class Host(object):
         conn = self._get_connection()
         runner = conn.sudo if with_sudo else conn.run
 
-        # Fabric 3's sudo() prepends "sudo -S -p '...' " directly to the
-        # command without wrapping it in a shell, unlike Fabric.
-        # This breaks commands containing shell constructs (while, for, if,
-        # pipes, etc.).  Wrap in "bash -c '...'" to restore the old behavior.
-        # Legacy fabric3 already shell-wraps sudo commands, so skip it there.
+        # Modern fabric's sudo() prepends "sudo -S -p '...'" with no shell, so
+        # shell constructs (pipes, while, &&) break.  Wrap in bash -c to keep
+        # them working; fabric3 already shell-wraps sudo, so skip it there.
         if with_sudo and args and not IS_LEGACY_FABRIC:
             cmd = args[0]
             args = (f"bash -c {shlex.quote(cmd)}",) + args[1:]

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -131,15 +131,14 @@ class Hypervisor(Host):
         """
         old_name = self.get_volume_by_vm(vm).name()
         new_name = vm.uid_name
-        with self.fabric_settings():
-            if old_name != new_name:
-                self.run(
-                    'lvrename {} {}'.format(
-                        self.get_volume_by_vm(vm).path(),
-                        vm.uid_name
-                    )
+        if old_name != new_name:
+            self.run(
+                'lvrename {} {}'.format(
+                    self.get_volume_by_vm(vm).path(),
+                    vm.uid_name
                 )
-                self.get_storage_pool(vg_name=vm.vg_name).refresh()
+            )
+            self.get_storage_pool(vg_name=vm.vg_name).refresh()
 
     def vm_mount_path(self, vm):
         """Returns the mount path for a VM or raises HypervisorError if not
@@ -872,7 +871,7 @@ class Hypervisor(Host):
         pool_info = self.get_storage_pool(vg_name=vg_name).info()
         # Floor instead of ceil because we check free instead of used space
         vg_size_gib = math.floor(float(pool_info[3]) / 1024 ** 3)
-        if safe is True:
+        if safe:
             vg_size_gib -= RESERVED_DISK[self.get_storage_type()]
         return vg_size_gib
 
@@ -903,7 +902,7 @@ class Hypervisor(Host):
                 'umount {0}'.format(device_or_path),
                 warn_only=(i < retry - 1),
             )
-            if res.succeeded:
+            if res.ok:
                 return
 
     def remove_temp(self, mount_path):

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -133,10 +133,7 @@ class Hypervisor(Host):
         new_name = vm.uid_name
         if old_name != new_name:
             self.run(
-                'lvrename {} {}'.format(
-                    self.get_volume_by_vm(vm).path(),
-                    vm.uid_name
-                )
+                f'lvrename {self.get_volume_by_vm(vm).path()} {vm.uid_name}'
             )
             self.get_storage_pool(vg_name=vm.vg_name).refresh()
 
@@ -877,8 +874,8 @@ class Hypervisor(Host):
 
     def mount_temp(self, device, suffix=''):
         """Mounts given device into temporary path"""
-        mount_dir = self.run('mktemp -d --suffix {}'.format(suffix))
-        self.run('mount {0} {1}'.format(device, mount_dir))
+        mount_dir = self.run(f'mktemp -d --suffix {suffix}')
+        self.run(f'mount {device} {mount_dir}')
         return mount_dir
 
     def umount_temp(self, device_or_path):

--- a/igvm/hypervisor.py
+++ b/igvm/hypervisor.py
@@ -467,7 +467,7 @@ class Hypervisor(Host):
             'set -e ; '
             'flock -w 120 9 ; '
             'curl -o {img_path}/{img_file}.md5 {md5_url} ; '
-            'sed -Ei \'s_ (.*/)?([a-zA-Z0-9\.\-]+)$_ {img_path}/\\2_\' '
+            "sed -Ei 's_ (.*/)?([a-zA-Z0-9\\.\\-]+)$_ {img_path}/\\2_' "
             '{img_path}/{img_file}.md5 ; '
             'md5sum -c {img_path}/{img_file}.md5 || '
             'curl -o {img_path}/{img_file} {img_url} ; '

--- a/igvm/kvm.py
+++ b/igvm/kvm.py
@@ -426,7 +426,7 @@ def generate_domain_xml(hypervisor, vm):
         log.info('KVM: Memory hotplug disabled, requires qemu 2.3')
 
     # Remove whitespace and re-indent properly.
-    out = re.sub(b'>\s+<', b'><', ElementTree.tostring(tree))
+    out = re.sub(rb'>\s+<', b'><', ElementTree.tostring(tree))
     domain_xml = minidom.parseString(out).toprettyxml()
     return domain_xml
 

--- a/igvm/puppet.py
+++ b/igvm/puppet.py
@@ -3,8 +3,11 @@
 Copyright (c) 2020 InnoGames GmbH
 """
 import random
+import socket
 from logging import getLogger
 from time import sleep
+
+import paramiko.ssh_exception
 
 from adminapi.dataset import Query, DatasetObject
 
@@ -12,6 +15,7 @@ from igvm.exceptions import ConfigError
 from igvm.fabric_compat import Connection, IS_LEGACY_FABRIC, make_fabric_config
 from igvm.host import CommandResult
 from igvm.settings import (
+    FABRIC_CONNECTION_ATTEMPTS,
     FABRIC_CONNECTION_DEFAULTS,
     IGVM_SSH_USER,
 )
@@ -100,21 +104,33 @@ def run_cmd(host: str, cmd: str):
     if IGVM_SSH_USER:
         conn_kwargs['user'] = IGVM_SSH_USER
 
-    conn = Connection(host, config=make_fabric_config(), **conn_kwargs)
-    try:
-        # Prepend a space to the command so that invoke's sudo() produces
-        # the two-space gap between the prompt and the command that the
-        # SSH_ORIGINAL_COMMAND whitelist on puppet CA hosts expects:
-        #   "sudo -S -p 'sudo password:'  <cmd>"
-        # invoke builds: "sudo -S -p '{prompt}' {cmd}" — one space from the
-        # format string plus our leading space gives the required two.
-        # Legacy fabric3's sudo() already produces the expected spacing, so
-        # there we pass the command unchanged.
-        cmd_arg = cmd if IS_LEGACY_FABRIC else (' ' + cmd)
-        result = conn.sudo(cmd_arg, hide=True, warn=True, pty=False)
-        return CommandResult(result)
-    finally:
-        conn.close()
+    # invoke's sudo() builds "sudo -S -p '{prompt}' {cmd}" (one space), but the
+    # CA whitelist wants two spaces before the command, so prepend one.
+    # fabric3's sudo() already spaces correctly, so pass it unchanged there.
+    cmd_arg = cmd if IS_LEGACY_FABRIC else (' ' + cmd)
+
+    # Retry transient SSH failures like Host.run(); command failures aren't
+    # retried (warn=True) — clean_cert() handles CA-level retries.
+    for attempt in range(FABRIC_CONNECTION_ATTEMPTS):
+        conn = Connection(host, config=make_fabric_config(), **conn_kwargs)
+        try:
+            result = conn.sudo(cmd_arg, hide=True, warn=True, pty=False)
+            return CommandResult(result)
+        except (
+            paramiko.ssh_exception.SSHException,
+            paramiko.ssh_exception.NoValidConnectionsError,
+            socket.error,
+            EOFError,
+        ):
+            if attempt < FABRIC_CONNECTION_ATTEMPTS - 1:
+                logger.warning(
+                    'Connection to %s lost, retrying (attempt %d/%d)...',
+                    host, attempt + 2, FABRIC_CONNECTION_ATTEMPTS,
+                )
+            else:
+                raise
+        finally:
+            conn.close()
 
 
 def find_puppet_executable(host: str) -> str:

--- a/igvm/puppet.py
+++ b/igvm/puppet.py
@@ -8,12 +8,10 @@ from time import sleep
 
 from adminapi.dataset import Query, DatasetObject
 
-import fabric
-
 from igvm.exceptions import ConfigError
+from igvm.fabric_compat import Connection, IS_LEGACY_FABRIC, make_fabric_config
 from igvm.host import CommandResult
 from igvm.settings import (
-    make_fabric_config,
     FABRIC_CONNECTION_DEFAULTS,
     IGVM_SSH_USER,
 )
@@ -102,7 +100,7 @@ def run_cmd(host: str, cmd: str):
     if IGVM_SSH_USER:
         conn_kwargs['user'] = IGVM_SSH_USER
 
-    conn = fabric.Connection(host, config=make_fabric_config(), **conn_kwargs)
+    conn = Connection(host, config=make_fabric_config(), **conn_kwargs)
     try:
         # Prepend a space to the command so that invoke's sudo() produces
         # the two-space gap between the prompt and the command that the
@@ -110,7 +108,10 @@ def run_cmd(host: str, cmd: str):
         #   "sudo -S -p 'sudo password:'  <cmd>"
         # invoke builds: "sudo -S -p '{prompt}' {cmd}" — one space from the
         # format string plus our leading space gives the required two.
-        result = conn.sudo(' ' + cmd, hide=True, warn=True, pty=False)
+        # Legacy fabric3's sudo() already produces the expected spacing, so
+        # there we pass the command unchanged.
+        cmd_arg = cmd if IS_LEGACY_FABRIC else (' ' + cmd)
+        result = conn.sudo(cmd_arg, hide=True, warn=True, pty=False)
         return CommandResult(result)
     finally:
         conn.close()

--- a/igvm/puppet.py
+++ b/igvm/puppet.py
@@ -13,6 +13,7 @@ import fabric
 from igvm.exceptions import ConfigError
 from igvm.host import CommandResult
 from igvm.settings import (
+    make_fabric_config,
     FABRIC_CONNECTION_DEFAULTS,
     IGVM_SSH_USER,
 )
@@ -101,9 +102,15 @@ def run_cmd(host: str, cmd: str):
     if IGVM_SSH_USER:
         conn_kwargs['user'] = IGVM_SSH_USER
 
-    conn = fabric.Connection(host, **conn_kwargs)
+    conn = fabric.Connection(host, config=make_fabric_config(), **conn_kwargs)
     try:
-        result = conn.sudo(cmd, hide=True, warn=True, pty=False)
+        # Prepend a space to the command so that invoke's sudo() produces
+        # the two-space gap between the prompt and the command that the
+        # SSH_ORIGINAL_COMMAND whitelist on puppet CA hosts expects:
+        #   "sudo -S -p 'sudo password:'  <cmd>"
+        # invoke builds: "sudo -S -p '{prompt}' {cmd}" — one space from the
+        # format string plus our leading space gives the required two.
+        result = conn.sudo(' ' + cmd, hide=True, warn=True, pty=False)
         return CommandResult(result)
     finally:
         conn.close()
@@ -159,7 +166,10 @@ def clean_cert_v6(
 
     # Check if the cleaning was successful or if there was nothing to
     # clean in the first place
-    if res.return_code == 1 and 'Could not find files to clean' in res:
+    if res.return_code == 1 and (
+        'Could not find files to clean' in res
+        or 'Could not find files to clean' in res.stderr
+    ):
         logger.debug(
             f'Skip revoking of {vm_host} because there is no valid '
             'certificate known to the CA',

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -21,21 +21,23 @@ from igvm.hypervisor_preferences import (
     OverAllocation,
 )
 
-COMMON_FABRIC_SETTINGS = dict(
-    disable_known_hosts=True,
-    use_ssh_config=True,
-    always_use_pty=stdout.isatty(),
-    forward_agent=True,
-    shell='/bin/sh -c',
-    timeout=5,
-    connection_attempts=3,
-    remote_interrupt=True,
+IGVM_SSH_USER = environ.get('IGVM_SSH_USER')
+
+FABRIC_CONNECTION_DEFAULTS = dict(
+    connect_timeout=5,
+    connect_kwargs={
+        'allow_agent': True,
+    },
 )
 
-# Can't not add a key with dict built above and None value gets interpreted
-# as "None" username, thus separate code.
-if 'IGVM_SSH_USER' in environ:
-    COMMON_FABRIC_SETTINGS['user'] = environ.get('IGVM_SSH_USER')
+if IGVM_SSH_USER:
+    FABRIC_CONNECTION_DEFAULTS['user'] = IGVM_SSH_USER
+
+FABRIC_RUN_DEFAULTS = dict(
+    pty=stdout.isatty(),
+)
+
+FABRIC_CONNECTION_ATTEMPTS = 3
 
 DEFAULT_VG_NAME = 'xen-data'
 # Reserved pool space on Hypervisor

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -6,6 +6,8 @@ Copyright (c) 2018 InnoGames GmbH
 from os import environ
 from sys import stdout
 
+import fabric
+
 from libvirt import (
     VIR_MIGRATE_PEER2PEER,
     VIR_MIGRATE_TLS,
@@ -32,6 +34,14 @@ FABRIC_CONNECTION_DEFAULTS = dict(
 
 if IGVM_SSH_USER:
     FABRIC_CONNECTION_DEFAULTS['user'] = IGVM_SSH_USER
+
+# Fabric 1.x used 'sudo password:' as the sudo prompt, while Fabric 3.x
+# defaults to '[sudo] password:'.  Remote hosts with SSH_ORIGINAL_COMMAND
+# whitelists match the old format, so we must keep using it.
+FABRIC_SUDO_PROMPT = 'sudo password:'
+
+def make_fabric_config():
+    return fabric.Config(overrides={'sudo': {'prompt': FABRIC_SUDO_PROMPT}})
 
 FABRIC_RUN_DEFAULTS = dict(
     pty=stdout.isatty(),

--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -6,8 +6,6 @@ Copyright (c) 2018 InnoGames GmbH
 from os import environ
 from sys import stdout
 
-import fabric
-
 from libvirt import (
     VIR_MIGRATE_PEER2PEER,
     VIR_MIGRATE_TLS,
@@ -34,14 +32,6 @@ FABRIC_CONNECTION_DEFAULTS = dict(
 
 if IGVM_SSH_USER:
     FABRIC_CONNECTION_DEFAULTS['user'] = IGVM_SSH_USER
-
-# Fabric 1.x used 'sudo password:' as the sudo prompt, while Fabric 3.x
-# defaults to '[sudo] password:'.  Remote hosts with SSH_ORIGINAL_COMMAND
-# whitelists match the old format, so we must keep using it.
-FABRIC_SUDO_PROMPT = 'sudo password:'
-
-def make_fabric_config():
-    return fabric.Config(overrides={'sudo': {'prompt': FABRIC_SUDO_PROMPT}})
 
 FABRIC_RUN_DEFAULTS = dict(
     pty=stdout.isatty(),

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -31,7 +31,7 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 from igvm.exceptions import ConfigError, HypervisorError, RemoteCommandError, VMError
-from igvm.host import CommandResult, Host
+from igvm.host import Host
 from igvm.settings import (
     AWS_ECU_FACTOR,
     AWS_FALLBACK_INSTANCE_TYPE,
@@ -830,7 +830,7 @@ class VM(Host):
                 break
             except ClientError as e:
                 raise VMError(e)
-            except CapacityNotAvailableError as e:
+            except CapacityNotAvailableError:
                 continue
 
         if run_puppet:
@@ -1049,7 +1049,7 @@ class VM(Host):
         self.put('/usr/sbin/policy-rc.d', fd, '0755')
 
     def unblock_autostart(self):
-        self.run('rm /usr/sbin/policy-rc.d')
+        self.run('rm -f /usr/sbin/policy-rc.d')
 
     def copy_postboot_script(self, script):
         self.put('/buildvm-postboot', script, '0755')

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -22,7 +22,6 @@ from typing import Optional, List, Union
 from uuid import uuid4
 
 import boto3
-import fabric
 import paramiko.ssh_exception
 from botocore.exceptions import ClientError, CapacityNotAvailableError
 from jinja2 import Environment, FileSystemLoader
@@ -31,6 +30,7 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 from igvm.exceptions import ConfigError, HypervisorError, RemoteCommandError, VMError
+from igvm.fabric_compat import Connection
 from igvm.host import Host
 from igvm.settings import (
     AWS_ECU_FACTOR,
@@ -857,7 +857,7 @@ class VM(Host):
                 continue
 
             try:
-                conn = fabric.Connection(
+                conn = Connection(
                     self.dataset_obj['hostname'],
                     **FABRIC_CONNECTION_DEFAULTS,
                 )

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -125,7 +125,7 @@ class VM(Host):
         template = env.get_template(filename)
         rendered = template.render(**(context or {}))
         fd = BytesIO(rendered.encode('utf-8'))
-        self.put(self.vm_path(destination), fd)
+        self.put(destination, fd)
 
     def get(self, remote_path, local_path):
         """" Same as Fabric's get() but works on mounted or running vm """
@@ -142,6 +142,7 @@ class VM(Host):
             seems broken, at least for mounted VM. This is why we run
             extra commands here.
         """
+        remote_path = self.vm_path(remote_path)
         if self.mounted:
             host_obj = self.hypervisor
         else:

--- a/igvm/vm.py
+++ b/igvm/vm.py
@@ -591,8 +591,7 @@ class VM(Host):
         """
         action = 'boot' if running else 'shutdown'
         for i in range(timeout, 1, -1):
-            print(
-                f'Waiting for VM "{self.fqdn}" to {action}... {i} s')
+            log.info(f'Waiting for VM "{self.fqdn}" to {action}... {i} s')
             if self.hypervisor.vm_running(self) == running:
                 return True
             time.sleep(1)
@@ -676,7 +675,7 @@ class VM(Host):
         self.hypervisor.check_vm(self, offline=True)
 
         if not run_puppet or self.dataset_obj['puppet_disabled']:
-            log.warn(
+            log.warning(
                 'Puppet is disabled on the VM.  It will not receive network '
                 'configuration.  Expect things to go south.'
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ netaddr~=0.8
 cffi>=1.14
 paramiko>=2.7
 fabric~=3.2
-libvirt-python>=7,<=9
+#libvirt-python>=7,<=11 # Use system package (python3-libvirt) instead
 jinja2~=2.11
 markupsafe~=1.1
 boto3~=1.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 setuptools~=73.0
 adminapi@git+https://github.com/innogames/serveradmin.git@v4.15.0#egg=adminapi
 netaddr~=0.8
-cffi~=1.14
-paramiko~=2.7
-Fabric3~=1.14
+cffi>=1.14
+paramiko>=2.7
+fabric~=3.2
 libvirt-python>=7,<=9
 jinja2~=2.11
 markupsafe~=1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ netaddr~=0.8
 cffi>=1.14
 paramiko>=2.7
 fabric~=3.2
-#libvirt-python>=7,<=11 # Use system package (python3-libvirt) instead
+libvirt-python>=7,<=11
 jinja2~=2.11
 markupsafe~=1.1
 boto3~=1.26

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ netaddr~=0.8
 cffi>=1.14
 paramiko>=2.7
 fabric~=3.2
-libvirt-python>=7,<=11
+libvirt-python>=7,<=12
 jinja2~=2.11
 markupsafe~=1.1
 boto3~=1.26

--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,38 @@
 Copyright (c) 2024 InnoGames GmbH
 """
 
+import re
+
 from setuptools import setup
 
 from igvm import VERSION
 
 
+# igvm runs with either modern "fabric" or legacy "fabric3" through
+# igvm.fabric_compat, so we deliberately do not hard-depend on one specific
+# fabric. requirements.txt still installs modern fabric for pip-based dev
+# setups; the Debian package expresses the choice as the alternative
+# dependency "python3-fabric | python3-fabric3" (see --depends3 in the deb
+# build). Without this, dh_python3 would turn the requirements.txt entry into
+# a strict "python3-fabric" dependency and the .deb would refuse to install on
+# fabric3-only hosts.
+_EXCLUDE_FROM_INSTALL_REQUIRES = {'fabric', 'fabric3'}
+
+
 def install_requires():
-    # This isn't the recommended way because install_requires and 
+    # This isn't the recommended way because install_requires and
     # requirements.txt are for different things but in our case this
     # is the bare minimum we need.
-    # 
+    #
     # See: https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements
     with open('requirements.txt') as f:
-        return f.readlines()
+        requirements = []
+        for line in f:
+            dist_name = re.split(r'[<>=~!;@\[ ]', line.strip(), maxsplit=1)[0]
+            if dist_name.lower() in _EXCLUDE_FROM_INSTALL_REQUIRES:
+                continue
+            requirements.append(line)
+        return requirements
 
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,7 +110,7 @@ def clean_hv(hv, pattern):
 
     # Cleanup igvm_locked status after a timeout
     if hv.dataset_obj['igvm_locked'] is not None:
-        now = datetime.utcnow().replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
         diff = now - hv.dataset_obj['igvm_locked']
 
         if diff >= IGVM_LOCKED_TIMEOUT:

--- a/tests/test_fabric_compat.py
+++ b/tests/test_fabric_compat.py
@@ -1,0 +1,180 @@
+"""igvm - Tests for the fabric compatibility shim
+
+Copyright (c) 2026 InnoGames GmbH
+
+These tests exercise igvm.fabric_compat against BOTH fabric flavors without
+needing fabric3 installed (it cannot be co-installed with modern fabric):
+
+* the modern path is asserted against the real, installed fabric;
+* the legacy path is asserted by injecting a fake ``fabric`` module that mimics
+  the fabric3 ``fabric.api`` surface and, crucially, has no ``Connection``
+  attribute, then loading a fresh copy of the shim against it.
+
+Neither test talks to the network or to serveradmin, so both run in plain CI.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from contextlib import contextmanager
+
+import igvm
+import igvm.fabric_compat as modern_compat
+
+
+class FakeFabric3Result(str):
+    """Mimics a fabric3 run()/sudo() result: a str that *is* stdout."""
+
+    def __new__(cls, stdout, return_code=0, stderr='', succeeded=True):
+        instance = super().__new__(cls, stdout)
+        instance.return_code = return_code
+        instance.stderr = stderr
+        instance.succeeded = succeeded
+        instance.failed = not succeeded
+        return instance
+
+
+def _build_fake_fabric(calls):
+    """Build a fake fabric3-style ``fabric`` package recording every call."""
+    fabric = types.ModuleType('fabric')
+    api = types.ModuleType('fabric.api')
+    state = types.ModuleType('fabric.state')
+    network = types.ModuleType('fabric.network')
+
+    class Env(dict):
+        def __getattr__(self, key):
+            return self.get(key)
+
+        def __setattr__(self, key, value):
+            self[key] = value
+
+    api.env = Env()
+    state.connections = {}
+
+    @contextmanager
+    def settings(*args, **kwargs):
+        calls.append(('settings', args, kwargs))
+        yield
+
+    def hide(*groups):
+        return ('hide', groups)
+
+    def run(command, **kwargs):
+        calls.append(('run', command, kwargs))
+        return FakeFabric3Result('ran:' + command)
+
+    def sudo(command, **kwargs):
+        calls.append(('sudo', command, kwargs))
+        return FakeFabric3Result('out:' + command)
+
+    def get(remote, local):
+        calls.append(('get', remote, local))
+
+    def put(local, remote):
+        calls.append(('put', local, remote))
+
+    def disconnect_all():
+        calls.append(('disconnect_all',))
+
+    api.settings = settings
+    api.hide = hide
+    api.run = run
+    api.sudo = sudo
+    api.get = get
+    api.put = put
+    network.disconnect_all = disconnect_all
+
+    fabric.api = api
+    fabric.state = state
+    fabric.network = network
+    # No fabric.Connection / fabric.Config: this is what marks it as legacy.
+    return fabric, api, state, network
+
+
+def _load_legacy_compat(monkeypatch, calls):
+    """Import a fresh copy of fabric_compat against the fake fabric3."""
+    fabric, api, state, network = _build_fake_fabric(calls)
+    monkeypatch.setitem(sys.modules, 'fabric', fabric)
+    monkeypatch.setitem(sys.modules, 'fabric.api', api)
+    monkeypatch.setitem(sys.modules, 'fabric.state', state)
+    monkeypatch.setitem(sys.modules, 'fabric.network', network)
+
+    path = os.path.join(os.path.dirname(igvm.__file__), 'fabric_compat.py')
+    spec = importlib.util.spec_from_file_location(
+        'igvm._fabric_compat_legacy_under_test', path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module, api
+
+
+# --------------------------------------------------------------------- modern
+
+def test_modern_fabric_detected():
+    import fabric
+
+    assert modern_compat.IS_LEGACY_FABRIC is False
+    assert modern_compat.Connection is fabric.Connection
+    config = modern_compat.make_fabric_config()
+    assert config.sudo['prompt'] == modern_compat.FABRIC_SUDO_PROMPT
+
+
+# --------------------------------------------------------------------- legacy
+
+def test_legacy_fabric_detected(monkeypatch):
+    module, api = _load_legacy_compat(monkeypatch, [])
+
+    assert module.IS_LEGACY_FABRIC is True
+    # The sudo prompt is forced onto the global env to match the whitelist.
+    assert api.env.sudo_prompt == module.FABRIC_SUDO_PROMPT
+    # make_fabric_config() still returns a config-like carrier.
+    assert module.make_fabric_config().sudo['prompt'] == \
+        module.FABRIC_SUDO_PROMPT
+
+
+def test_legacy_sudo_maps_kwargs_and_result(monkeypatch):
+    calls = []
+    module, _ = _load_legacy_compat(monkeypatch, calls)
+
+    conn = module.Connection('host1', user='bob')
+    result = conn.sudo('whoami', hide=True, warn=True, pty=False)
+
+    # Result adapter exposes the modern attribute names.
+    assert result.stdout == 'out:whoami'
+    assert result.ok is True
+    assert result.failed is False
+    assert result.return_code == 0
+
+    settings_calls = [c for c in calls if c[0] == 'settings']
+    assert settings_calls, 'sudo() must open a settings() context'
+    _, settings_args, settings_kwargs = settings_calls[-1]
+    # warn=True -> warn_only=True; host_string + user are propagated.
+    assert settings_kwargs['warn_only'] is True
+    assert settings_kwargs['host_string'] == 'host1'
+    assert settings_kwargs['user'] == 'bob'
+    # hide=True -> a hide('everything') context manager is passed positionally.
+    assert ('hide', ('everything',)) in settings_args
+
+    sudo_calls = [c for c in calls if c[0] == 'sudo']
+    assert sudo_calls == [('sudo', 'whoami', {'pty': False})]
+
+
+def test_legacy_run_no_shell_wrap(monkeypatch):
+    calls = []
+    module, _ = _load_legacy_compat(monkeypatch, calls)
+
+    conn = module.Connection('host2')
+    # Modern shell='' ("don't wrap in a shell") -> fabric3 shell=False.
+    conn.run('id', shell='')
+
+    run_calls = [c for c in calls if c[0] == 'run']
+    assert run_calls == [('run', 'id', {'shell': False})]
+
+
+def test_legacy_disconnect_all(monkeypatch):
+    calls = []
+    module, _ = _load_legacy_compat(monkeypatch, calls)
+
+    module.disconnect_all()
+    assert ('disconnect_all',) in calls

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,8 +14,7 @@ from unittest import TestCase
 from adminapi import api
 from adminapi.dataset import Query
 from adminapi.filters import Any
-from fabric.api import env
-from fabric.network import disconnect_all
+from igvm.host import disconnect_all
 from mock import patch
 
 from igvm.commands import (
@@ -47,7 +46,6 @@ from igvm.hypervisor import Hypervisor
 from igvm.puppet import clean_cert
 from igvm.settings import (
     AWS_RETURN_CODES,
-    COMMON_FABRIC_SETTINGS,
     HYPERVISOR_ATTRIBUTES,
     HYPERVISOR_CPU_THRESHOLDS,
     KVM_HWMODEL_TO_CPUMODEL,
@@ -63,9 +61,7 @@ from tests.conftest import (
 )
 
 basicConfig(level=INFO)
-env.update(COMMON_FABRIC_SETTINGS)
 environ['IGVM_SSH_USER'] = 'igtesting'  # Enforce user for integration testing
-env.user = 'igtesting'
 environ['IGVM_MODE'] = 'staging'
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,7 +14,7 @@ from unittest import TestCase
 from adminapi import api
 from adminapi.dataset import Query
 from adminapi.filters import Any
-from igvm.host import disconnect_all
+from igvm.fabric_compat import disconnect_all
 from unittest.mock import patch
 
 from igvm.commands import (

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,7 @@ from adminapi import api
 from adminapi.dataset import Query
 from adminapi.filters import Any
 from igvm.host import disconnect_all
-from mock import patch
+from unittest.mock import patch
 
 from igvm.commands import (
     _get_vm,


### PR DESCRIPTION
Our current Fabric3 is quite outdated and causing more and more compatibility issues (like python3.13)
-> use the maintained "fabric" version

already tested: basic VM start/stop/build/delete/sync/info/restart/disk-set/mem-set
todo: migration (offline + online) / AWS / rename / vcpu-set 