### PR TITLE
Calculate full XFS size, not usable size

### DIFF
--- a/igvm/settings.py
+++ b/igvm/settings.py
@@ -70,12 +70,19 @@ KVM_HWMODEL_TO_CPUMODEL = {
     'EPYC': ['Dell_R6515', 'Dell_R7515', 'Supermicro_H13S'],
 }
 
+# Compatibility options used when making a new filesystems.
+# This is configured per VM's operating system because the VM's kernel
+# must be able to boot from and mount the FS. But we also limit it
+# to the oldest Hypervisor we have, because the HV must be able to
+# make the filesystem and mount it for building or for VM offline
+# XFS-aware migrations and disk shrinking.
+# Currently we cap it at Bookworm with kernel 6.1.
 XFS_CONFIG = {
     'buster': ["-c options=/usr/share/xfsprogs/mkfs/lts_4.19.conf"],
     'bullseye': ["-c options=/usr/share/xfsprogs/mkfs/lts_5.10.conf"],
     'bookworm': ["-c options=/usr/share/xfsprogs/mkfs/lts_6.1.conf"],
-    'trixie': ["-c options=/usr/share/xfsprogs/mkfs/lts_6.12.conf"],
-    'rolling': ["-c options=/usr/share/xfsprogs/mkfs/lts_6.12.conf"],
+    'trixie': ["-c options=/usr/share/xfsprogs/mkfs/lts_6.1.conf"],
+    'rolling': ["-c options=/usr/share/xfsprogs/mkfs/lts_6.1.conf"],
 }
 
 PUPPET_BINARY_PATH = {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,6 +4,8 @@ Copyright (c) 2020 InnoGames GmbH
 """
 from __future__ import print_function
 
+import re
+
 from logging import INFO, basicConfig
 from os import environ
 from tempfile import NamedTemporaryFile
@@ -52,7 +54,6 @@ from igvm.settings import (
     DEFAULT_VG_NAME,
     VM_ATTRIBUTES
 )
-from igvm.utils import parse_size
 from igvm.vm import VM
 from tests import VM_HOSTNAME, VM_NET
 from tests.conftest import (
@@ -343,11 +344,30 @@ class CommandTest(IGVMTest):
                 )
 
             def _get_disk_vm():
-                return parse_size(
-                    self.vm.run("df -h / | tail -n+2 | awk '{ print $2 }'")
-                    .strip(),
-                    'G'
-                )
+                xfs_info = self.vm.run("xfs_info /")
+
+                block_size = None
+                total_blocks = None
+                section = None
+
+                for line in xfs_info.splitlines():
+                    line = line.strip()
+                    if line and not line.startswith("="):
+                        section = line.split("=", 1)[0].strip()
+
+                    if section == "data":
+                        match = re.search(r"bsize=(\d+)", line)
+                        if match:
+                            block_size = int(match.group(1))
+                        match = re.search(r"blocks=(\d+)", line)
+                        if match:
+                            total_blocks = int(match.group(1))
+
+                if block_size is None or total_blocks is None:
+                    raise ValueError(f"Failed to parse xfs_info output: {xfs_info}")
+
+                return (total_blocks * block_size) / (1024**3)
+
         elif self.datacenter_type == 'aws.dct':
             def _get_disk_vm():
                 partition = self.vm.run('findmnt -nro SOURCE /')


### PR DESCRIPTION
When building VMs we require a specific disk size and that ends up being the block device size. When a filesystem is created in this block device it might have some overhead. This overhead was quite small on older Debian releases but on Trixie it has grown quite a bit. The growth is mostly attributed to the log. It was ~160MiB before and is ~371MiB now.

Update the test function _get_disk_vm() to get the raw XFS size, because that's the one which should be identical to the block device size.